### PR TITLE
FEAT: Manually Deploy Odin to Dev

### DIFF
--- a/.github/workflows/deploy_base.yaml
+++ b/.github/workflows/deploy_base.yaml
@@ -1,0 +1,62 @@
+name: AWS Deploy Base
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: One of 'prod', 'staging', or 'dev'
+        required: true
+        type: string
+      deploy-odin:
+        description: Should the Odin Application be Deployed
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      DOCKER_REPO:
+        description: ECR Docker repo to push to
+        required: true
+      AWS_ROLE_ARN:
+        description: AWS_ROLE_ARN
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        id: setup-aws
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Extract version information
+        id: generate-version
+        run: |
+          git fetch --tags
+          VERSION=$(git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n 1)
+          SHA=$(git rev-parse --short HEAD)
+          FULL_VERSION="${VERSION}-${SHA}"
+          echo "version=${FULL_VERSION}" >> $GITHUB_ENV
+      - name: Build and Push Docker Image
+        id: build-push
+        uses: mbta/actions/build-push-ecr@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
+          docker-additional-args: --build-arg VERSION=${{ env.version }}
+      - name: Deploy Odin Application
+        id: deploy-odin
+        if: ${{ inputs.deploy-odin }}
+        uses: mbta/actions/deploy-ecs@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          ecs-cluster: odin
+          ecs-service: odin-${{ inputs.environment }}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+          allow-zero-desired: false

--- a/.github/workflows/manual-deploy.yaml
+++ b/.github/workflows/manual-deploy.yaml
@@ -1,0 +1,26 @@
+name: Manual Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment
+        type: choice
+        options:
+          - dev
+      deploy-odin:
+        description: Deploy Odin
+        default: false
+        type: boolean
+
+jobs:
+  deploy:
+    concurrency:
+      group: github.event.inputs.environment
+    uses: ./.github/workflows/deploy-base.yaml
+    with:
+      # pass the inputs from the workflow dispatch through to the deploy base. the booleans are
+      # converted to strings, so flip them back using fromJson function
+      environment: ${{ github.event.inputs.environment }}
+      deploy-odin: ${{ fromJson(github.event.inputs.deploy-odin) }}
+    secrets: inherit


### PR DESCRIPTION
GHA workflow for deploying Odin to dev.

Broken into two files, a deploy-base, which will allow for parallel deploy of future odin-esq applications. And the `manual-deploy` which calls `deploy-base` with required inputs. 

In the future this will be adjusted to allow for deploy to prod, along with automated deploys based on PR merge and/or application versioning. 