### PR TITLE
FIX: run each Job in Process to free resources

### DIFF
--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -441,7 +441,7 @@ class CubicODSFact(OdinJob):
         return next_run_secs
 
 
-def cubic_ods_gen_fact_schedule(schedule: sched.scheduler) -> None:
+def schedule_cubic_ods_fact_gen(schedule: sched.scheduler) -> None:
     """
     Schedule All Jobs for generate cubic ODS fact tables process.
 

--- a/src/odin/ingestion/qlik/cubic_archive.py
+++ b/src/odin/ingestion/qlik/cubic_archive.py
@@ -2,6 +2,7 @@ import os
 import gzip
 import shutil
 import hashlib
+import sched
 import tempfile
 
 from datetime import datetime
@@ -14,6 +15,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from odin.utils.logger import ProcessLog
 from odin.job import OdinJob
+from odin.job import job_proc_schedule
 from odin.utils.runtime import thread_cpus
 from odin.utils.aws.s3 import S3Object
 from odin.utils.aws.s3 import upload_file
@@ -33,6 +35,8 @@ from odin.ingestion.qlik.utils import snapshot_to_parquet
 from odin.ingestion.qlik.utils import re_get_first
 from odin.ingestion.qlik.dfm import QlikDFM
 from odin.ingestion.qlik.dfm import dfm_snapshot_dt
+from odin.ingestion.qlik.tables import CUBIC_ODS_TABLES
+from odin.ingestion.qlik.clean import clean_old_snapshots
 from odin.utils.locations import CUBIC_QLIK_DATA
 from odin.utils.locations import DATA_SPRINGBOARD
 from odin.utils.locations import DATA_ARCHIVE
@@ -340,3 +344,22 @@ class ArchiveCubicQlikTable(OdinJob):
             next_run_secs = 60 * 60
 
         return next_run_secs
+
+
+def cubic_archive_qlik_schedule(schedule: sched.scheduler) -> None:
+    """
+    Schedule All Jobs for Cubic Qlik Archive process.
+
+    :param schedule: application scheduler
+    """
+    for table in CUBIC_ODS_TABLES:
+        # This will be not be a permanent part of the pipeline and can be removed in the future
+        # This will move any qlik files, not associated with the most recent snapshot, to the
+        # "Ignore" odin partition
+        try:
+            clean_old_snapshots(table)
+        except Exception as _:
+            # skip table processing if error occurs
+            continue
+        job = ArchiveCubicQlikTable(table)
+        schedule.enter(0, 1, job_proc_schedule, (job, schedule))

--- a/src/odin/ingestion/qlik/cubic_archive.py
+++ b/src/odin/ingestion/qlik/cubic_archive.py
@@ -346,7 +346,7 @@ class ArchiveCubicQlikTable(OdinJob):
         return next_run_secs
 
 
-def cubic_archive_qlik_schedule(schedule: sched.scheduler) -> None:
+def schedule_cubic_archive_qlik(schedule: sched.scheduler) -> None:
     """
     Schedule All Jobs for Cubic Qlik Archive process.
 

--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -65,7 +65,7 @@ class OdinJob(ABC):
 
         finally:
             self.reset_tmpdir()
-        
+
         return run_delay_secs
 
 
@@ -73,11 +73,11 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler) -> None:
     """
     Odin Job Runner as Process.
 
-    This function runs each OdinJob as it's own process so resource usage can be fully cleaned 
-    after each job completion.
+    This function runs each OdinJob as it's own process so resource usage can be fully cleared
+    between job runs.
 
     :param job: Job to be run and re-scheduled
-    :param schedule: main applicated scheduler
+    :param schedule: main application scheduler
     """
     with get_context("spawn").Pool(1) as pool:
         run_delay_secs = pool.apply(job.start)

--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -14,6 +14,7 @@ from odin.utils.logger import LOGGER_NAME
 from odin.utils.logger import LOG_FORMAT
 from odin.utils.logger import DATE_FORMAT
 from odin.utils.logger import log_max_mem_usage
+from odin.job import job_proc_schedule
 from odin.ingestion.qlik.cubic_archive import ArchiveCubicQlikTable
 from odin.generate.cubic.ods_fact import CubicODSFact
 from odin.ingestion.qlik.tables import CUBIC_ODS_TABLES
@@ -50,7 +51,7 @@ def start():
         ],
     )
 
-    scheduler = sched.scheduler(time.monotonic, time.sleep)
+    schedule = sched.scheduler(time.monotonic, time.sleep)
 
     log = ProcessLog("odin_event_loop")
 
@@ -65,11 +66,11 @@ def start():
                 # skip table processing if error occurs
                 continue
         job = ArchiveCubicQlikTable(table)
-        scheduler.enter(0, 1, job.start, (scheduler,))
+        schedule.enter(0, 1, job_proc_schedule, (job, schedule,))
         job = CubicODSFact(table)
-        scheduler.enter(0, 1, job.start, (scheduler,))
+        schedule.enter(0, 1, job_proc_schedule, (job, schedule,))
 
-    scheduler.run()
+    schedule.run()
     log.complete()
 
 

--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -17,8 +17,8 @@ from odin.utils.logger import log_max_mem_usage
 
 # Job Schedule functions
 from odin.utils.runtime import schedule_sigterm_check
-from odin.ingestion.qlik.cubic_archive import cubic_archive_qlik_schedule
-from odin.generate.cubic.ods_fact import cubic_ods_gen_fact_schedule
+from odin.ingestion.qlik.cubic_archive import schedule_cubic_archive_qlik
+from odin.generate.cubic.ods_fact import schedule_cubic_ods_fact_gen
 
 
 def start():
@@ -56,8 +56,8 @@ def start():
 
     # Schedule ODIN Jobs
     schedule_sigterm_check(schedule)
-    cubic_archive_qlik_schedule(schedule)
-    cubic_ods_gen_fact_schedule(schedule)
+    schedule_cubic_archive_qlik(schedule)
+    schedule_cubic_ods_fact_gen(schedule)
 
     schedule.run()
     log.complete()

--- a/src/odin/utils/aws/s3.py
+++ b/src/odin/utils/aws/s3.py
@@ -18,7 +18,7 @@ from botocore.response import StreamingBody
 from odin.utils.logger import ProcessLog
 from odin.utils.runtime import thread_cpus
 
-S3_POOL_COUNT = 50
+S3_POOL_COUNT = 30 * thread_cpus()
 
 
 class S3Object(NamedTuple):

--- a/src/odin/utils/runtime.py
+++ b/src/odin/utils/runtime.py
@@ -86,7 +86,7 @@ def sigterm_check() -> None:
 
 def schedule_sigterm_check(schedule: sched.scheduler) -> None:
     """
-    Schedule sigterm check to run always be running inbetween jobs.
+    Schedule sigterm check to always be running between idle jobs.
 
     :param schedule: application scheduler
     """

--- a/src/odin/utils/runtime.py
+++ b/src/odin/utils/runtime.py
@@ -1,4 +1,5 @@
 import os
+import sched
 import sys
 from typing import List
 from typing import Optional
@@ -81,3 +82,14 @@ def sigterm_check() -> None:
     if os.environ.get("GOT_SIGTERM") is not None:
         ProcessLog("stopping_ecs")
         sys.exit(0)
+
+
+def schedule_sigterm_check(schedule: sched.scheduler) -> None:
+    """
+    Schedule sigterm check to run always be running inbetween jobs.
+
+    :param schedule: application scheduler
+    """
+    sig_check_delay_secs = 30
+    sigterm_check()
+    schedule.enter(sig_check_delay_secs, 1, schedule_sigterm_check, (schedule,))


### PR DESCRIPTION
Constructing jobs as python Class objects seems to cause an issue with clearing resources between job runs. I believe this is related to the long-lived classes hanging on to resources after a job has completed. 

To resolve this issue, this change runs each OdinJob inside of a process using the `job_proc_schedule` function as the `sched.scheduler` callback. 

This change was deployed to Dev yesterday evening and resulted the the following change to memory usage:
![image](https://github.com/user-attachments/assets/31e2d683-3201-4f28-ab19-43a20a2cc624)

As can be seen, memory usage between job runs now drops to almost 0. 