### PR TITLE
[FEAT] New parquet dataset min_max function based on dataset metadata

### DIFF
--- a/src/odin/ingestion/qlik/cubic_archive.py
+++ b/src/odin/ingestion/qlik/cubic_archive.py
@@ -14,6 +14,7 @@ from itertools import batched
 from concurrent.futures import ThreadPoolExecutor
 
 from odin.utils.logger import ProcessLog
+from odin.utils.runtime import sigterm_check
 from odin.job import OdinJob
 from odin.job import job_proc_schedule
 from odin.utils.runtime import thread_cpus
@@ -139,6 +140,8 @@ class ArchiveCubicQlikTable(OdinJob):
             export_file_prefix="month",
         )
 
+        # Check for sigterm before upload (can't be un-done)
+        sigterm_check()
         for new_path in new_paths:
             # Save merged parquet paths to local disk
             if self.save_local:


### PR DESCRIPTION
The `pyarrow.acero` based `ds_column_min_max` function was becoming slow on very large PROD ODS datasets. 

This change adds a parquet dataset min_max function based on the dataset metadata. It only pulls file metadata so is very fast for very large parquet datasets. This will only work if the dataset has statistics written to the parquet file, which all ODIN parquet files do. 

For the `cubic_qlik/EDW.DEVICE_EVENT` dataset, which is about 10GB in size (~319,810,572 rows):

```
%timeit -n 5 -r 5  ds_metadata_min_max(ds, "header__change_seq")
# 492 ms ± 254 ms per loop (mean ± std. dev. of 5 runs, 5 loops each)
# mem usage ~ 180mb

%timeit -n 1 -r 1  ds_column_min_max(ds, "header__change_seq")
# 1min 55s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
# mem usage ~640mb
```