### PR TITLE
remove unneeded configurability

### DIFF
--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -1,4 +1,3 @@
-import os
 import sched
 import signal
 import time

--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -36,7 +36,6 @@ def start():
     fail in a way that interrupts the execution of subsequently scheduled jobs.
     """
     signal.signal(signal.SIGTERM, handle_sigterm)
-    os.environ["SERVICE_NAME"] = "odin"
     validate_env_vars(
         required=[
             "DATA_ARCHIVE",

--- a/src/odin/utils/logger.py
+++ b/src/odin/utils/logger.py
@@ -22,10 +22,8 @@ def free_disk_bytes() -> int:
 MdValues = Optional[Union[str, int, float]]
 
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
-LOG_FORMAT = "{asctime} {levelname:>8s} {message}"
-# if running on AWS drop timestamp because Splunk handles that
-if bool(os.getenv("AWS_DEFAULT_REGION")):
-    LOG_FORMAT = "{levelname:>8s} {message}"
+# skip "{asctime}" timestamp because Splunk handles that.
+LOG_FORMAT = "{levelname:>8s} {message}"
 
 # Use/Create logger based on SERVICE_NAME, don't use root logger
 LOGGER_NAME = "odin_app"

--- a/src/odin/utils/logger.py
+++ b/src/odin/utils/logger.py
@@ -25,7 +25,7 @@ DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 # skip "{asctime}" timestamp because Splunk handles that.
 LOG_FORMAT = "{levelname:>8s} {message}"
 
-# Use/Create logger based on SERVICE_NAME, don't use root logger
+# Use/Create logger based on service name, don't use root logger
 LOGGER_NAME = "odin_app"
 LOGGER = logging.getLogger(LOGGER_NAME)
 if len(LOGGER.handlers) == 0:
@@ -63,7 +63,7 @@ class ProcessLog:
         self.default_data: Dict[str, MdValues] = {}
         self.metadata: Dict[str, MdValues] = {}
 
-        self.default_data["parent"] = os.getenv("SERVICE_NAME", "unset")
+        self.default_data["parent"] = "odin"
         self.default_data["process"] = process
 
         self.start_time = 0.0

--- a/src/odin/utils/logger.py
+++ b/src/odin/utils/logger.py
@@ -22,8 +22,10 @@ def free_disk_bytes() -> int:
 MdValues = Optional[Union[str, int, float]]
 
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
-# skip "{asctime}" timestamp because Splunk handles that.
-LOG_FORMAT = "{levelname:>8s} {message}"
+LOG_FORMAT = "{asctime} {levelname:>8s} {message}"
+# if running on AWS drop timestamp because Splunk handles that
+if bool(os.getenv("AWS_DEFAULT_REGION")):
+    LOG_FORMAT = "{levelname:>8s} {message}"
 
 # Use/Create logger based on service name, don't use root logger
 LOGGER_NAME = "odin_app"

--- a/src/odin/utils/runtime.py
+++ b/src/odin/utils/runtime.py
@@ -23,9 +23,6 @@ def validate_env_vars(
     """
     logger = ProcessLog("validate_env_vars")
 
-    # every pipeline needs a service name for logging
-    required.append("SERVICE_NAME")
-
     if private is None:
         private = []
 

--- a/src/odin/utils/runtime.py
+++ b/src/odin/utils/runtime.py
@@ -62,12 +62,9 @@ def thread_cpus() -> int:
     """
     os_cpu_count = os.cpu_count()
     if os_cpu_count is None:
-        os_cpu_count = 4
-
-    if running_in_aws():
-        os_cpu_count *= 2
-
-    return os_cpu_count
+        return 8
+    else:
+        return os_cpu_count * 2
 
 
 def handle_sigterm(_: int, __: Any) -> None:

--- a/tests/utils/runtime_test.py
+++ b/tests/utils/runtime_test.py
@@ -11,12 +11,10 @@ from odin.utils.runtime import sigterm_check
 
 def test_validate_env_vars(caplog, monkeypatch) -> None:
     """Test validate_env_vars util."""
-    # Should throw because "SERVICE_NAME" is not set
-    with pytest.raises(RuntimeError):
-        validate_env_vars(required=[])
+    # Passes if no requirements
+    validate_env_vars(required=[])
     caplog.clear()
 
-    monkeypatch.setenv("SERVICE_NAME", "odin")
     monkeypatch.setenv("PRIVATE", "hide_me")
     monkeypatch.setenv("REQUIRED", "see_me")
     monkeypatch.setenv("IN_AWS", "true")

--- a/tests/utils/runtime_test.py
+++ b/tests/utils/runtime_test.py
@@ -45,20 +45,13 @@ def test_validate_env_vars(caplog, monkeypatch) -> None:
         assert "IN_AWS=true" not in caplog.messages[-1]
 
 
-@patch("odin.utils.runtime.running_in_aws")
 @patch("odin.utils.runtime.os.cpu_count")
-def test_thread_cpus(cpu_count: MagicMock, running_aws: MagicMock) -> None:
+def test_thread_cpus(cpu_count: MagicMock) -> None:
     """Test thread_cpus util."""
-    running_aws.return_value = False
-    cpu_count.return_value = 100
+    cpu_count.return_value = 50
     assert thread_cpus() == 100
 
-    running_aws.return_value = False
     cpu_count.return_value = None
-    assert thread_cpus() == 4
-
-    running_aws.return_value = True
-    cpu_count.return_value = 4
     assert thread_cpus() == 8
 
 


### PR DESCRIPTION
Asana Task: [Make Odin more configurable](https://app.asana.com/0/1209584755824899/1209886680141188/f)

I'm planning to refactor how config is specified. That will be easier if there are fewer things that need to be configured between different environments. So this removes configurability for a couple things that don't need it.

No changes in prod. Minor changes when developing locally.
- Always set the number of threads is 2x the number of cpus.
  - This was already the case in AWS.
  - This doubles the number of threads when not running in AWS.
- Remove timestamp from local logging.
  - It was already not used in AWS.
  - This is a change when not running locally, but the timestamp isn't really that useful anyway and kind of noisy.
- Remove the SERVICE_NAME env var
  - It was set in the app and only used in one place, so this removes some code with no change in behavior.