### PR TITLE
fix: pass save_local to find_qlik_load_files

### DIFF
--- a/src/odin/ingestion/qlik/cubic_archive.py
+++ b/src/odin/ingestion/qlik/cubic_archive.py
@@ -205,7 +205,7 @@ class ArchiveCubicQlikTable(OdinJob):
         added to the same snapshot partition.
         """
         snapshot_group: List[Tuple[str, QlikDFM]] = []
-        for path, dfm in find_qlik_load_files(self.table):
+        for path, dfm in find_qlik_load_files(self.table, self.save_local):
             if path.endswith("00001.csv.gz"):
                 self.process_snapshot_group(snapshot_group)
                 snapshot_group.clear()

--- a/src/odin/ingestion/qlik/utils.py
+++ b/src/odin/ingestion/qlik/utils.py
@@ -65,7 +65,7 @@ def re_get_first(string: str, pattern: re.Pattern) -> str:
     return match.group(0)
 
 
-def find_qlik_load_files(table: str, save_local=bool) -> List[Tuple[str, QlikDFM]]:
+def find_qlik_load_files(table: str, save_local: bool) -> List[Tuple[str, QlikDFM]]:
     """
     Get sorted List of LOAD***.csv.gz from from bucket locations
 


### PR DESCRIPTION
Noticed while doing #11 ([comment](https://github.com/mbta/odin/pull/11#discussion_r2033489255)), but was removed from that PR.

This looks like an unintentional typo, setting `save_local` to the default value `bool` instead of it being a type annotation. I believe the effect would be that in AWS, the `save_local` path (utils.py line 88) would always be taken, because the value `bool` is truthy. After this change, that path would no longer be taken.