### PR TITLE
FEAT: New ds_metadata_limit_k_sorted function for parquet

### DIFF
--- a/src/odin/utils/parquet.py
+++ b/src/odin/utils/parquet.py
@@ -8,6 +8,7 @@ from typing import Optional
 from typing import List
 from typing import Any
 from typing import Literal
+from typing import TypedDict
 from functools import reduce
 from operator import gt
 from operator import lt
@@ -110,6 +111,47 @@ def pq_rows_per_mb(source: Union[str, Sequence[str]], num_rows: Optional[int] = 
     return rows_per_mb
 
 
+class RowGroupStats(TypedDict):
+    """Incomplete representation of Stats fields, but only ones currently used."""
+
+    max: Any
+    min: Any
+
+
+def row_group_column_stats(rg_metadata: pq.RowGroupMetaData, column: str) -> RowGroupStats:
+    """
+    Retrieve 'column' statistics from metadata of row group.
+
+    :param rg_metadata: Metadata of parquet row group.
+    :param column: Name of column to retrieve stats for.
+
+    :return: Dictionary of column stats for row group.
+    """
+    rg_dict = rg_metadata.to_dict()
+    for col in rg_dict["columns"]:
+        if col["path_in_schema"] != column:  # type: ignore[index]
+            continue
+        return col["statistics"]  # type: ignore[index]
+
+    raise IndexError(f"{column} not round in row group metadata")
+
+
+def pq_path_partitions(path: str) -> List[Tuple[str, str]]:
+    """
+    Extract partition columns for parquet file path.
+
+    :param path: path of parquet file
+
+    :return: List of (column_name, column_value) tuples extracted from 'path'
+    """
+    file_partitions = []
+    for part in path.split("/"):
+        if "=" in part:
+            col, value = part.split("=", 1)
+            file_partitions.append((col, value))
+    return file_partitions
+
+
 def ds_files(ds: pd.UnionDataset) -> List[str]:
     """
     Produce list of paths found in dataset.
@@ -154,19 +196,26 @@ def ds_from_path(source: Union[str, Sequence[str]]) -> pd.UnionDataset:
 
 
 def ds_column_min_max(
-    ds: pd.Dataset, column: str, ds_filter: Optional[pd.Expression] = None
+    ds: pd.Dataset,
+    column: str,
+    ds_filter: Optional[pd.Expression] = None,
+    filter_cols: Optional[List[str]] = None,
 ) -> Tuple[Any, Any]:
     """
     Get min & max value of column from pyarrow Dataset.
 
     :param ds: pyarrow.Dataset to scan
     :param column: column to query
-    :param filter: (Optional) Expression filter to apply during scan
-
+    :param ds_filter: (Optional) Expression filter to apply during scan
+    :param filter_cols: (Optional) Any columns, that are not 'column', used in 'ds_filter'
+                        Expression. Not including these will nullify 'ds_filter'
     :return: (min, max)
     """
+    if filter_cols is None:
+        filter_cols = []
+    scan_cols = list(set([column] + filter_cols))
     agg_col = "__agg_result"
-    scan_node = ac.ScanNodeOptions(ds, columns=[column], batch_readahead=0, fragment_readahead=1)  # type: ignore[attr-defined]
+    scan_node = ac.ScanNodeOptions(ds, columns=scan_cols, batch_readahead=0, fragment_readahead=1)  # type: ignore[attr-defined]
     declarations = [ac.Declaration("scan", scan_node)]
     if ds_filter is not None:
         declarations.append(ac.Declaration("filter", ac.FilterNodeOptions(ds_filter)))
@@ -197,7 +246,13 @@ def ds_metadata_min_max(ds: pd.UnionDataset, column: str) -> Tuple[Any, Any]:
     This is a very fast and efficient way to get min/max from large dataset with accurate
     metadata statistics.
 
+<<<<<<< HEAD
     Will return (None,None) if column is all NULL values.
+=======
+    If the `column` contains all NULL values, return values will be `None`.
+
+    If the `column` is a path partition, return values will be type str.
+>>>>>>> f9fbe4d (metadata limit_k_sorted)
 
     :param ds: pyarrow.Dataset to scan
     :param column: column to query
@@ -219,22 +274,21 @@ def ds_metadata_min_max(ds: pd.UnionDataset, column: str) -> Tuple[Any, Any]:
                 continue
             for frag in child.get_fragments():
                 metadata: pq.FileMetaData = frag.metadata
+                if column in ds.schema.names and column not in metadata.schema.names:
+                    # column in dataset but not fragment file
+                    continue
                 for rg_index in range(metadata.num_row_groups):
-                    rg_meta = metadata.row_group(rg_index).to_dict()
-                    for col in rg_meta["columns"]:
-                        if col["path_in_schema"] != column:  # type: ignore[index]
-                            continue
-                        if col["statistics"]["min"] is not None:  # type: ignore[index]
-                            column_mins.append(col["statistics"]["min"])  # type: ignore[index]
-                        if col["statistics"]["max"] is not None:  # type: ignore[index]
-                            column_maxs.append(col["statistics"]["max"])  # type: ignore[index]
-                        break
-        if len(column_mins) == 0:
-            column_mins.append(None)
-        if len(column_maxs) == 0:
-            column_maxs.append(None)
-        col_min = min(column_mins)
-        col_max = max(column_maxs)
+                    col_stats = row_group_column_stats(metadata.row_group(rg_index), column)
+                    if col_stats["min"] is not None:
+                        column_mins.append(col_stats["min"])
+                    if col_stats["max"] is not None:
+                        column_maxs.append(col_stats["max"])
+        col_min = None
+        if column_mins:
+            col_min = min(column_mins)
+        col_max = None
+        if column_maxs:
+            col_max = max(column_maxs)
         log.complete()
     except Exception as exception:
         log.failed(exception)
@@ -291,6 +345,7 @@ def ds_limit_k_sorted(
     log = ProcessLog(
         "ds_limit_k_sorted",
         sort_column=sort_column,
+        batch_size=batch_size,
         sort_direction=sort_direction,
         max_nbytes=max_nbytes,
     )
@@ -323,10 +378,127 @@ def ds_limit_k_sorted(
                 result_batch = result_batch.slice(length=max_result_rows)
             result_compare_value = result_compare_op(result_batch.column(sort_column)).as_py()
 
-    log.complete(num_results=result_batch.num_rows)
     return_df = pl.from_arrow(result_batch)
     if isinstance(return_df, pl.Series):
         raise TypeError("Always dataframe.")
+    log.complete(num_results=result_batch.num_rows)
+    return return_df
+
+
+def ds_metadata_limit_k_sorted(
+    ds: pd.UnionDataset,
+    sort_column: str,
+    min_sort_value: Any | None = None,
+    ds_filter: pc.Expression | None = None,
+    ds_filter_columns: List[str] | None = None,
+    max_nbytes: int = 256 * 1024 * 1024,
+) -> pl.DataFrame:
+    """
+    Produce limited number of sorted (ascending) results from large parquet dataset.
+
+    This function attempts to increase dataset scan performance by using parquet metadata to skip
+    the reading of entire row groups. Performance is best if parquet files are loosely sorted by
+    sort_column across dataset row groups.
+
+    Any records with a NULL value in 'sort_column' or 'ds_filter_columns' will be ignored.
+
+    :param ds: Dataset to scan, can not be filtered.
+    :param sort_column: Column to sort results on.
+    :param min_sort_value: (Optional) minimum value to include in results (exclusive).
+    :param ds_filter: (Optional) Expression filter to apply during scan
+    :param ds_filter_columns: (Optional) Any columns, that are not 'sort_column', used in
+                              'ds_filter' Expression.
+                              In the future, maybe, these columns can be extracted from 'ds_filter'
+    :param max_nbytes: Max bytes (reported by RecordBatch.nbytes) to keep in results.
+
+    :return: polars Dataframe of sorted results
+    """
+    log = ProcessLog(
+        "ds_metadata_limit_k_sorted",
+        sort_column=sort_column,
+        max_nbytes=max_nbytes,
+        min_sort_value=min_sort_value,
+    )
+    bytes_read = 0
+    max_result_rows = 0
+    if ds_filter_columns is None:
+        ds_filter_columns = []
+    scan_cols = list(set([sort_column] + ds_filter_columns))
+    result_table = pa.Table.from_pylist([], schema=ds.schema)
+    result_max = None
+    for child in ds.children:
+        for file in child.files:  # type: ignore[attr-defined]
+            pq_file = pq.ParquetFile(file, filesystem=child.filesystem)  # type: ignore[attr-defined]
+            # if any scan_cols in dataset but not fragment file, skip fragment
+            if set(scan_cols) <= set(ds.schema.names) and bool(
+                set(scan_cols) - set(pq_file.schema_arrow.names)
+            ):
+                continue
+            pq_metadata = pq_file.metadata
+            for rg_index in range(pq_metadata.num_row_groups):
+                # filter row group by metadata (min/max sort value only)
+                col_stats = row_group_column_stats(pq_metadata.row_group(rg_index), sort_column)
+                if col_stats["min"] is None or col_stats["max"] is None:
+                    continue
+                if min_sort_value is not None and col_stats["max"] <= min_sort_value:
+                    continue
+                if result_max is not None and col_stats["min"] > result_max:
+                    continue
+                # filter row group by min_sort_value and/or ds_filter
+                # to limit data transfer initial filter limited to 'scan_cols'
+                rg_table = pq_file.read_row_group(rg_index, columns=scan_cols)
+                try:
+                    if ds_filter is not None:
+                        rg_table = rg_table.filter(ds_filter)
+                    if min_sort_value is not None:
+                        rg_table = rg_table.filter((pc.field(sort_column) > min_sort_value))
+                except IndexError:
+                    # IndexError is raised if .filter() produces no results???
+                    continue
+                if rg_table.num_rows == 0:
+                    continue
+                # read/filter entire row group
+                rg_table = pq_file.read_row_group(rg_index)
+                if ds_filter is not None:
+                    rg_table = rg_table.filter(ds_filter)
+                if min_sort_value is not None:
+                    rg_table = rg_table.filter((pc.field(sort_column) > min_sort_value))
+                # add parition columns to row group table, if they exist
+                # ParquetFile does not include parition columns when reading row groups
+                # all partition columns added as strings, but cast back to dataset types later
+                file_partitions = pq_path_partitions(file)
+                for part_col, part_val in file_partitions:
+                    if part_col not in pq_file.schema_arrow.names:
+                        rg_table = rg_table.append_column(
+                            part_col,
+                            pa.array([part_val] * rg_table.num_rows, pa.string()),
+                        )
+                # add dataset columns that may not be in file as all Null
+                for ds_col in ds.schema.names:
+                    if ds_col not in rg_table.column_names:
+                        rg_table = rg_table.append_column(
+                            ds_col,
+                            pa.array([None] * rg_table.num_rows, pa.string()),
+                        )
+                cast_schema = pa.schema([ds.schema.field(col) for col in rg_table.column_names])
+                rg_table = rg_table.cast(cast_schema)
+                bytes_read += rg_table.nbytes
+                result_table = pa.concat_tables(
+                    [result_table, rg_table],
+                    promote_options="default",
+                ).sort_by([(sort_column, "ascending")])
+                # if max_nbytes reached in dataset, begin filtering by max sort_column value
+                if bytes_read > max_nbytes:
+                    if max_result_rows == 0:
+                        max_result_rows = result_table.num_rows
+                    result_table = result_table.slice(length=max_result_rows)
+                result_max = pc.max(result_table.column(sort_column)).as_py()
+            pq_file.close()
+            del pq_file
+    return_df = pl.from_arrow(result_table)
+    if isinstance(return_df, pl.Series):
+        raise TypeError("Always dataframe.")
+    log.complete(num_results=result_table.num_rows)
     return return_df
 
 

--- a/src/odin/utils/parquet.py
+++ b/src/odin/utils/parquet.py
@@ -246,13 +246,9 @@ def ds_metadata_min_max(ds: pd.UnionDataset, column: str) -> Tuple[Any, Any]:
     This is a very fast and efficient way to get min/max from large dataset with accurate
     metadata statistics.
 
-<<<<<<< HEAD
-    Will return (None,None) if column is all NULL values.
-=======
     If the `column` contains all NULL values, return values will be `None`.
 
     If the `column` is a path partition, return values will be type str.
->>>>>>> f9fbe4d (metadata limit_k_sorted)
 
     :param ds: pyarrow.Dataset to scan
     :param column: column to query

--- a/tests/utils/parquet_test.py
+++ b/tests/utils/parquet_test.py
@@ -1,11 +1,13 @@
 import os
+import shutil
 import pytest
-from typing import List
+from typing import Generator
 from pathlib import Path
 
 import polars as pl
 import pyarrow.dataset as pd
 import pyarrow.compute as pc
+import pyarrow.parquet as pq
 
 from odin.utils.parquet import pq_rows_and_bytes
 from odin.utils.parquet import pq_rows_per_mb
@@ -15,22 +17,27 @@ from odin.utils.parquet import ds_column_min_max
 from odin.utils.parquet import ds_metadata_min_max
 from odin.utils.parquet import ds_unique_values
 from odin.utils.parquet import _pq_find_part_offset
+from odin.utils.parquet import ds_metadata_limit_k_sorted
+from odin.utils.parquet import pq_path_partitions
+from odin.utils.parquet import row_group_column_stats
+
 
 PQ_NUM_ROWS = 500_000
 PQ_MAX_INT = 50_000
 
 
-@pytest.fixture
-def pq_files(tmp_path) -> List[str]:
+@pytest.fixture(scope="module")
+def pq_files(tmp_path_factory) -> Generator[list[str]]:
     """Create temporary parquet files for testing."""
+    tmp_path = tmp_path_factory.mktemp("pq_files", numbered=False)
     pq_files = []
     pq_files.append(os.path.join(tmp_path, "file=t1", "t1.parquet"))
     os.makedirs(os.path.dirname(pq_files[-1]), exist_ok=True)
     (
         pl.DataFrame()
         .with_columns(
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row1"),
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row2"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col1"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col2"),
         )
         .write_parquet(pq_files[-1], row_group_size=int(PQ_NUM_ROWS / 10))
     )
@@ -40,10 +47,10 @@ def pq_files(tmp_path) -> List[str]:
     (
         pl.DataFrame()
         .with_columns(
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row1"),
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row2"),
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row3"),
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row4"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col1"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col2"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col3"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col4"),
         )
         .write_parquet(pq_files[-1], row_group_size=int(PQ_NUM_ROWS / 10))
     )
@@ -53,18 +60,19 @@ def pq_files(tmp_path) -> List[str]:
     (
         pl.DataFrame()
         .with_columns(
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row1"),
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row2"),
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row3"),
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row4"),
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row5"),
-            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("row6"),
-            pl.lit("single_value").alias("row7"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col1"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col2"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col3"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col4"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col5"),
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("col6"),
+            pl.lit("single_value").alias("col7"),
         )
         .write_parquet(pq_files[-1], row_group_size=int(PQ_NUM_ROWS / 10))
     )
 
-    return pq_files
+    yield pq_files
+    shutil.rmtree(tmp_path)
 
 
 def test_pq_rows_and_bytes(pq_files) -> None:
@@ -106,25 +114,25 @@ def test_ds_column_min_max(pq_files) -> None:
     """Test ds_column_min_max parquet utility."""
     # Keep an eye on this test, the source data is technically random so this could fail...
     ds = ds_from_path(pq_files)
-    assert ds_column_min_max(ds, "row1") == (0, PQ_MAX_INT - 1)
+    assert ds_column_min_max(ds, "col1") == (0, PQ_MAX_INT - 1)
 
     # test partition column
     assert ds_column_min_max(ds, "file") == ("t1", "t3")
 
-    ds_filter = pc.field("row1") < 50
-    assert ds_column_min_max(ds, "row1", ds_filter) == (0, 49)
+    ds_filter = pc.field("col1") < 50
+    assert ds_column_min_max(ds, "col1", ds_filter) == (0, 49)
 
 
 def test_ds_metadata_min_max(pq_files) -> None:
     """Test ds_column_min_max parquet utility."""
     # Keep an eye on this test, the source data is technically random so this could fail...
     ds = ds_from_path(pq_files)
-    assert ds_metadata_min_max(ds, "row1") == (0, PQ_MAX_INT - 1)
+    assert ds_metadata_min_max(ds, "col1") == (0, PQ_MAX_INT - 1)
 
     # test partition column
     assert ds_metadata_min_max(ds, "file") == ("t1", "t3")
 
-    assert ds_metadata_min_max(ds, "row7") == ("single_value", "single_value")
+    assert ds_metadata_min_max(ds, "col7") == ("single_value", "single_value")
 
 
 def test_ds_unique_values(tmp_path) -> None:
@@ -162,3 +170,66 @@ def test__pq_find_part_offset(tmp_path) -> None:
 
     os.remove(file2)
     assert _pq_find_part_offset(tmp_fldr) == 2
+
+
+def test_pq_path_partitions(pq_files) -> None:
+    """Test pq_path_partitions parquet utility."""
+    pq_path = "/test/path/no/partition.parquet"
+    assert pq_path_partitions(pq_path) == []
+
+    pq_path = "/test/path/col1=val1/partition.parquet"
+    assert pq_path_partitions(pq_path) == [("col1", "val1")]
+
+    pq_path = "/test/path/col1=val1/col2=99/partition.parquet"
+    assert pq_path_partitions(pq_path) == [("col1", "val1"), ("col2", "99")]
+
+    assert pq_path_partitions(pq_files[0]) == [("file", "t1")]
+
+
+def test_row_group_column_stats(pq_files) -> None:
+    """Test row_group_column_stats parquet utility."""
+    pq_file = pq.ParquetFile(pq_files[0])
+    pq_metadata = pq_file.metadata
+    for rg_index in range(pq_file.num_row_groups):
+        rg_meta = pq_metadata.row_group(rg_index)
+        with pytest.raises(IndexError):
+            row_group_column_stats(rg_meta, "col7")
+
+        stats = row_group_column_stats(rg_meta, "col1")
+        assert stats["max"] <= PQ_MAX_INT - 1
+        assert stats["min"] >= 0
+
+        stats = row_group_column_stats(rg_meta, "col2")
+        assert stats["max"] <= PQ_MAX_INT - 1
+        assert stats["min"] >= 0
+
+
+def test_ds_metadata_limit_k_sorted(pq_files) -> None:
+    """
+    Test ds_metadata_limit_k_sorted parquet utility.
+
+    The scope of this test is pretty limited and could be expanded...
+    """
+    ds = ds_from_path(pq_files)
+
+    # test column not in all files
+    df = ds_metadata_limit_k_sorted(ds, "col7")
+    assert df.shape == (PQ_NUM_ROWS, 8)
+
+    df = ds_metadata_limit_k_sorted(ds, "col1")
+    assert df.shape == (PQ_NUM_ROWS * 3, 8)
+    assert df.get_column("col1")[0] == 0
+    assert df.get_column("col1")[-1] == PQ_MAX_INT - 1
+
+    df = ds_metadata_limit_k_sorted(ds, "col1", min_sort_value=500)
+    assert df.width == 8
+    assert df.height < PQ_NUM_ROWS * 3
+    assert df.get_column("col1")[0] == 501
+    assert df.get_column("col1")[-1] == PQ_MAX_INT - 1
+
+    df = ds_metadata_limit_k_sorted(
+        ds, "col1", ds_filter=(pc.field("col7") == "single_value"), ds_filter_columns=["col7"]
+    )
+    assert df.shape == (PQ_NUM_ROWS, 8)
+    assert df.get_column("col1")[0] == 0
+    assert df.get_column("col1")[-1] == PQ_MAX_INT - 1

--- a/tests/utils/parquet_test.py
+++ b/tests/utils/parquet_test.py
@@ -216,6 +216,9 @@ def test_ds_metadata_limit_k_sorted(pq_files) -> None:
     df = ds_metadata_limit_k_sorted(ds, "col7")
     assert df.shape == (PQ_NUM_ROWS, 8)
 
+    df = ds_metadata_limit_k_sorted(ds, "col7", max_rows=200)
+    assert df.shape == (200, 8)
+
     df = ds_metadata_limit_k_sorted(ds, "col1")
     assert df.shape == (PQ_NUM_ROWS * 3, 8)
     assert df.get_column("col1")[0] == 0


### PR DESCRIPTION
This change adds a new `ds_metadata_limit_k_sorted` function to pull records from large parquet datasets in a more performant manner in some situations. 