### PR TITLE
chore: Drop INCOMING bucket env var

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,5 +3,4 @@
 # S3 Buckets
 DATA_ARCHIVE=mbta-ctd-dataplatform-dev-archive
 DATA_ERROR=mbta-ctd-dataplatform-dev-error
-DATA_INCOMING=mbta-ctd-dataplatform-dev-incoming
 DATA_SPRINGBOARD=mbta-ctd-dataplatform-dev-springboard

--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -39,7 +39,6 @@ def start():
         required=[
             "DATA_ARCHIVE",
             "DATA_ERROR",
-            "DATA_INCOMING",
             "DATA_SPRINGBOARD",
         ],
         aws=[

--- a/src/odin/utils/locations.py
+++ b/src/odin/utils/locations.py
@@ -3,7 +3,6 @@ import os
 # bucket constants
 DATA_ARCHIVE = os.getenv("DATA_ARCHIVE", "unset_DATA_ARCHIVE")
 DATA_ERROR = os.getenv("DATA_ERROR", "unset_DATA_ERROR")
-DATA_INCOMING = os.getenv("DATA_INCOMING", "unset_DATA_INCOMING")
 DATA_SPRINGBOARD = os.getenv("DATA_SPRINGBOARD", "unset_DATA_SPRINGBOARD")
 
 # ODIN


### PR DESCRIPTION
Incoming bucket is not used in any ODIN operations, can be dropped as env var. 

This change will require a devops PR before merging. 

Devops PR blocked by terraform_modules PR: https://github.com/mbta/terraform_modules/pull/163