### PR TITLE
FIX: Drop manual /tmp folde cleanup in all Jobs

### DIFF
--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -10,7 +10,7 @@ import sched
 from odin.utils.logger import ProcessLog
 from odin.utils.logger import MdValues
 from odin.utils.runtime import sigterm_check
-from odin.utils.runtime import delete_folder_contens
+from odin.utils.runtime import delete_folder_items
 from odin.utils.aws.ecs import running_in_aws
 
 NEXT_RUN_DEFAULT = 60 * 60 * 6  # 6 hours
@@ -102,6 +102,6 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler) -> None:
 
     # always clear temp directory in AWS (in case of process getting killed)
     if running_in_aws():
-        delete_folder_contens(tempfile.gettempdir())
+        delete_folder_items(tempfile.gettempdir())
 
     schedule.enter(proc_return_val.value, 1, job_proc_schedule, (job, schedule))

--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -10,8 +10,6 @@ import sched
 from odin.utils.logger import ProcessLog
 from odin.utils.logger import MdValues
 from odin.utils.runtime import sigterm_check
-from odin.utils.runtime import delete_folder_items
-from odin.utils.aws.ecs import running_in_aws
 
 NEXT_RUN_DEFAULT = 60 * 60 * 6  # 6 hours
 NEXT_RUN_FAILED = 60 * 60 * 24  # 24 hours
@@ -99,9 +97,5 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler) -> None:
         )
         fail_log.failed(SystemError("OdinJob killed by ECS."))
         proc_return_val.value = NEXT_RUN_FAILED
-
-    # always clear temp directory in AWS (in case of process getting killed)
-    if running_in_aws():
-        delete_folder_items(tempfile.gettempdir())
 
     schedule.enter(proc_return_val.value, 1, job_proc_schedule, (job, schedule))

--- a/src/odin/utils/runtime.py
+++ b/src/odin/utils/runtime.py
@@ -125,23 +125,3 @@ def infinite_wait(reason: str) -> None:
         # sleep
         time.sleep(sleep_time)
         count += 1
-
-
-def delete_folder_items(folder: str) -> None:
-    """
-    Delete contents of entire folder.
-
-    :param folder: folder that will have items deleted, folder will remain (empty)
-    """
-    log = ProcessLog("delete_folder_items", folder=folder)
-    for entry in os.listdir(folder):
-        path = os.path.join(folder, entry)
-        try:
-            if os.path.isfile(path) or os.path.islink(path):
-                os.unlink(path)
-            elif os.path.isdir(path):
-                shutil.rmtree(path)
-        except Exception as _:
-            pass
-
-    log.complete()

--- a/src/odin/utils/runtime.py
+++ b/src/odin/utils/runtime.py
@@ -127,12 +127,13 @@ def infinite_wait(reason: str) -> None:
         count += 1
 
 
-def delete_folder_contens(folder: str) -> None:
+def delete_folder_items(folder: str) -> None:
     """
     Delete contents of entire folder.
 
-    :param folder: folder that will have contents deleted, folder will remain (empty)
+    :param folder: folder that will have items deleted, folder will remain (empty)
     """
+    log = ProcessLog("delete_folder_items", folder=folder)
     for entry in os.listdir(folder):
         path = os.path.join(folder, entry)
         try:
@@ -142,3 +143,5 @@ def delete_folder_contens(folder: str) -> None:
                 shutil.rmtree(path)
         except Exception as _:
             pass
+
+    log.complete()


### PR DESCRIPTION
Reverting the addition of the `delete_folder_contens` (spelling) function.

This change resulted in some kind of race condition with the regular `/tmp` folder cleanup process. Shelving this idea for now, but need to re-visit if a specific job failure mode causes disk space issues. 