### PR TITLE
FIX: S&B API load_sids logic

### DIFF
--- a/src/odin/migrate/migrations/odin-dev/0002.py
+++ b/src/odin/migrate/migrations/odin-dev/0002.py
@@ -1,0 +1,21 @@
+import os
+
+from odin.utils.aws.s3 import list_objects
+from odin.utils.aws.s3 import delete_objects
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.locations import AFC_DATA
+
+
+def migration() -> None:
+    """
+    ODIN DEV Migration 0002.
+
+    May 7, 2025
+
+    This migration is to reset S&B API files because of error in SID pagination logic.
+    After deletion, files will be re-created on next ArchiveAFCAPI job runs.
+
+    1. Delete all parquet files from S&B API prefix.
+    """
+    sb_prefix = os.path.join(DATA_SPRINGBOARD, AFC_DATA)
+    delete_objects([obj.path for obj in list_objects(sb_prefix)])

--- a/src/odin/migrate/migrations/odin-prod/0002.py
+++ b/src/odin/migrate/migrations/odin-prod/0002.py
@@ -1,0 +1,21 @@
+import os
+
+from odin.utils.aws.s3 import list_objects
+from odin.utils.aws.s3 import delete_objects
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.locations import AFC_DATA
+
+
+def migration() -> None:
+    """
+    ODIN PROD Migration 0002.
+
+    May 7, 2025
+
+    This migration is to reset S&B API files because of error in SID pagination logic.
+    After deletion, files will be re-created on next ArchiveAFCAPI job runs.
+
+    1. Delete all parquet files from S&B API prefix.
+    """
+    sb_prefix = os.path.join(DATA_SPRINGBOARD, AFC_DATA)
+    delete_objects([obj.path for obj in list_objects(sb_prefix)])

--- a/tests/ingestion/afc/afc_archive_test.py
+++ b/tests/ingestion/afc/afc_archive_test.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import call
+
+import polars as pl
+
+from odin.ingestion.afc.afc_archive import ArchiveAFCAPI
+from odin.ingestion.afc.afc_archive import make_pl_schema
+
+
+@patch.object(ArchiveAFCAPI, "download_csv")
+@patch("odin.ingestion.afc.afc_archive.disk_free_pct")
+def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
+    """Test load_sids method of ArchiveAFCAPI"""
+    disk_free.return_value = 99
+    job = ArchiveAFCAPI("test_table")
+    test_schema = [
+        {"column_name": "col1", "data_type": "bigint"},
+        {"column_name": "col2", "data_type": "integer"},
+        {"column_name": "col3", "data_type": "varchar"},
+        {"column_name": "col4", "data_type": "timestamp with time zone"},
+        {"column_name": "col5", "data_type": "varchar"},
+    ]
+    expected_schema = pl.Schema(
+        {
+            "col1": pl.Int64(),
+            "col2": pl.Int32(),
+            "col3": pl.String(),
+            "col4": pl.String(),
+            "col5": pl.String(),
+        }
+    )
+    job.schema = make_pl_schema(test_schema)
+    assert job.schema == expected_schema
+
+    # Test initial pull
+    job.job_ids = None
+    job.last_sid = None
+    job.load_sids()
+    dl_csv.assert_called_once_with(None)
+    dl_csv.reset_mock()
+
+    # Test jobId skipping
+    job.last_sid = 1000
+    job.job_ids = [
+        {"jobId": 1, "dataCount": 1},
+        {"jobId": 2, "dataCount": 1},
+        {"jobId": 3, "dataCount": 1},
+        {"jobId": 4, "dataCount": 1},
+        {"jobId": 5, "dataCount": 1},
+        {"jobId": 6, "dataCount": 1},
+        {"jobId": 7, "dataCount": 1},
+        {"jobId": 8, "dataCount": 1},
+        {"jobId": 9, "dataCount": 1},
+        {"jobId": 1000, "dataCount": 1},
+        {"jobId": 1001, "dataCount": 1},
+    ]
+    job.load_sids()
+    dl_csv.assert_called_once_with(1001, 1001)
+    dl_csv.reset_mock()
+
+    # Test target_rows hit
+    job.job_ids = [
+        {"jobId": 1, "dataCount": 1},
+        {"jobId": 1000, "dataCount": 1},
+        {"jobId": 1001, "dataCount": 1_000_000},
+        {"jobId": 1002, "dataCount": 500},
+    ]
+    job.load_sids()
+    dl_csv.assert_has_calls([call(1001, 1001), call(1002, 1002)])
+    dl_csv.reset_mock()
+
+    # Test combine jobIds
+    job.job_ids = [
+        {"jobId": 1, "dataCount": 1},
+        {"jobId": 1000, "dataCount": 1},
+        {"jobId": 1001, "dataCount": 500},
+        {"jobId": 1002, "dataCount": 500},
+    ]
+    job.load_sids()
+    dl_csv.assert_called_once_with(1001, 1002)
+    dl_csv.reset_mock()
+
+    # Test disk_free_pct hit
+    disk_free.return_value = 50
+    job.load_sids()
+    dl_csv.assert_called_once_with(1001, 1001)
+    dl_csv.reset_mock()


### PR DESCRIPTION
This change fixes the logic used for the `load_sids` method of the `ArchiveAFCAPI` Job. 

After deployment to PROD it was identified that incremental data loading was not occurring as expected. This change fixes the incremental loading logic of `load_sids` and also adds tests to ensure proper functioning of the method. 

To reset the S&B API datasest this change includes a migration that will delete all existing API data. Additional devops permissions are required to execute this migration. 

terraform_modules PR: https://github.com/mbta/terraform_modules/pull/209

devops PR: https://github.com/mbta/devops/pull/2858