### PR TITLE
feat: Verify AFC API Downloads

### DIFF
--- a/tests/ingestion/afc/afc_archive_test.py
+++ b/tests/ingestion/afc/afc_archive_test.py
@@ -84,6 +84,24 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
     )
     dl_csv.reset_mock()
 
+    # Confirm job sorting
+    job.job_ids = [
+        {"jobId": 1002, "dataCount": 200},
+        {"jobId": 1001, "dataCount": 500},
+        {"jobId": 1004, "dataCount": 500},
+        {"jobId": 1003, "dataCount": 300},
+    ]
+    job.load_sids()
+    dl_csv.assert_called_once_with(
+        [
+            {"jobId": 1001, "dataCount": 500},
+            {"jobId": 1002, "dataCount": 200},
+            {"jobId": 1003, "dataCount": 300},
+            {"jobId": 1004, "dataCount": 500},
+        ]
+    )
+    dl_csv.reset_mock()
+
     # Test disk_free_pct hit
     disk_free.return_value = 50
     job.load_sids()

--- a/tests/ingestion/afc/afc_archive_test.py
+++ b/tests/ingestion/afc/afc_archive_test.py
@@ -49,7 +49,7 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
         {"jobId": 1001, "dataCount": 1},
     ]
     job.load_sids()
-    dl_csv.assert_called_once_with(1001, 1001)
+    dl_csv.assert_called_once_with([{"jobId": 1001, "dataCount": 1}])
     dl_csv.reset_mock()
 
     # Test target_rows hit
@@ -60,7 +60,12 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
         {"jobId": 1002, "dataCount": 500},
     ]
     job.load_sids()
-    dl_csv.assert_has_calls([call(1001, 1001), call(1002, 1002)])
+    dl_csv.assert_has_calls(
+        [
+            call([{"jobId": 1001, "dataCount": 1_000_000}]),
+            call([{"jobId": 1002, "dataCount": 500}]),
+        ]
+    )
     dl_csv.reset_mock()
 
     # Test combine jobIds
@@ -71,11 +76,16 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
         {"jobId": 1002, "dataCount": 500},
     ]
     job.load_sids()
-    dl_csv.assert_called_once_with(1001, 1002)
+    dl_csv.assert_called_once_with(
+        [
+            {"jobId": 1001, "dataCount": 500},
+            {"jobId": 1002, "dataCount": 500},
+        ]
+    )
     dl_csv.reset_mock()
 
     # Test disk_free_pct hit
     disk_free.return_value = 50
     job.load_sids()
-    dl_csv.assert_called_once_with(1001, 1001)
+    dl_csv.assert_called_once_with([{"jobId": 1001, "dataCount": 500}])
     dl_csv.reset_mock()


### PR DESCRIPTION
This change updates the AFC API download process to verify all files received from the API.

This verification will compare results from the `count` endpoint to data in the csv returned from the `stagetable` endpoint.

Data received from the `count` endpoint is in the following format:
```
[
  {"jobId": 1, "dataCount": 10},
  {"jobId": 2, "dataCount": 5},
  {"jobId": 3, "dataCount": 12},
]
```

In this data `jobId==sid`. We will compare this `count` data to a `group_by` aggregation on the `sid` column of the csv files received and check for:
1. sid(s) in csv file that are not in `count` results.
2. sid(s) in `count` results that are not in csv file.
3. equal record counts in csv file and `dataCount` values from API