### PR TITLE
feat: Automatic Odin Data Dictionary Export

### DIFF
--- a/src/odin/generate/data_dictionary/dictionary.py
+++ b/src/odin/generate/data_dictionary/dictionary.py
@@ -1,0 +1,116 @@
+import os
+import json
+import sched
+from dataclasses import dataclass
+from dataclasses import asdict
+from typing import Generator
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from odin.job import OdinJob
+from odin.job import job_proc_schedule
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.locations import ODIN_DATA
+from odin.utils.locations import ODIN_DICTIONARY
+from odin.utils.aws.s3 import list_objects
+from odin.utils.aws.s3 import list_partitions
+from odin.utils.aws.s3 import upload_file
+
+NEXT_RUN_DEFAULT = 60 * 60 * 12  # 12 hours
+ODIN_ROOT = f"s3://{os.path.join(DATA_SPRINGBOARD, ODIN_DATA)}"
+
+
+@dataclass
+class DatasetField:
+    """Values exepcted for DatasetField"""
+
+    column_name: str
+    column_type: str
+    is_partition: bool
+
+    def __init__(self, column: pa.Field) -> None:
+        """Create DatasetField from pyarrow field."""
+        self.column_type = str(column.type)
+        if isinstance(column.type, pa.DictionaryType):
+            self.column_type = str(column.type.value_type)
+        self.column_name = column.name
+        # in testing DictionaryType is always partition column, futher testing may change this...
+        self.is_partition = isinstance(column.type, pa.DictionaryType)
+
+
+@dataclass
+class DatasetDictionary:
+    """Values expected for DatasetDictionary"""
+
+    dataset_group: str
+    dataset_name: str
+    dataset_path: str
+    size_mb: int
+    child_files: list[str]
+    schema: list[DatasetField]
+
+    def __init__(self, ds_path: str) -> None:
+        """Create DatasetDictionary from datset path."""
+        data_objects = list_objects(ds_path, in_filter=".parquet")
+        self.dataset_group = os.path.dirname(ds_path).replace(ODIN_ROOT, "").strip("/")
+        self.dataset_name = os.path.basename(ds_path)
+        self.dataset_path = ds_path
+        self.size_mb = int(sum([obj.size_bytes for obj in data_objects]) / (1024 * 1024))
+        self.child_files = [obj.path for obj in data_objects]
+        self.schema = [DatasetField(c) for c in pq.ParquetDataset(ds_path).schema]
+
+
+def generate_dictionary(path: str) -> Generator[dict[str, Any]]:
+    """Recursively generate DatabaseDictionary objects."""
+    path_parts = list_partitions(path)
+    if len(path_parts) == 0 or "=" in "".join(path_parts):
+        yield asdict(DatasetDictionary(ds_path=path))
+    else:
+        for part in path_parts:
+            yield from generate_dictionary(os.path.join(path, part))
+
+
+class DataDictionary(OdinJob):
+    """Generate Data Dictionary for Odin Springboard partition."""
+
+    def run(self) -> int:
+        """
+        Create ODIN DataDictionary exports.
+
+        Dictionary format for each dataset entry:
+        {
+            "child_files": list[S3 objects in dataset]
+            "dataset_group": common path stripped of ODIN_ROOT and dataset_name
+            "dataset_name": prefix immedieatly before start of dataset
+            "datasetpath": ODIN_ROOT + dataset_group + dataset_name
+            "schema": List[
+                {
+                    "column_name": name
+                    "column_type": type
+                    "is_partition": column derived for S3 partition
+                },
+            ]
+        }
+
+        """
+        data_dictionary = [d for d in generate_dictionary(ODIN_ROOT)]
+
+        json_tmp = os.path.join(self.tmpdir, "temp.json")
+        with open(json_tmp, "w") as json_writer:
+            json.dump(data_dictionary, json_writer)
+
+        upload_path = os.path.join(DATA_SPRINGBOARD, ODIN_DICTIONARY, "data_dictionary.json")
+        upload_file(json_tmp, upload_path)
+        return NEXT_RUN_DEFAULT
+
+
+def schedule_dictionary(schedule: sched.scheduler) -> None:
+    """
+    Schedule DataDictionary process.
+
+    :param schedule: application scheduler
+    """
+    job = DataDictionary()
+    schedule.enter(0, 1, job_proc_schedule, (job, schedule))

--- a/src/odin/utils/locations.py
+++ b/src/odin/utils/locations.py
@@ -11,6 +11,7 @@ ODIN_DATA = "odin/data"
 ODIN_ARCHIVE = "odin/archive"
 ODIN_ERROR = "odin/error"
 ODIN_MIGRATIONS = "odin/migrations"
+ODIN_DICTIONARY = f"{ODIN_DATA}/dictionary"
 
 # CUBIC QLIK
 IN_QLIK_PREFIX = "cubic/ods_qlik"

--- a/tests/generate/data_dictionary_test.py
+++ b/tests/generate/data_dictionary_test.py
@@ -1,0 +1,95 @@
+import os
+import shutil
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+import polars as pl
+
+from odin.generate.data_dictionary.dictionary import generate_dictionary
+from odin.utils.aws.s3 import S3Object
+
+PQ_NUM_ROWS = 5_000
+PQ_MAX_INT = 5_000
+
+
+def mock_list_objects(path: str, **kwargs):
+    """Mock list_objects for local call."""
+    objects = []
+    for dir, _, fnames in os.walk(path):
+        objects += [
+            S3Object(path=os.path.join(dir, f), size_bytes=0, last_modified="now") for f in fnames
+        ]
+    return objects
+
+
+def mock_list_partitions(path: str):
+    """Mock list_partitions for local call."""
+    return [d for d in os.listdir(path) if os.path.isdir(os.path.join(path, d))]
+
+
+@pytest.fixture(scope="module")
+def pq_file(tmp_path_factory) -> Generator[str]:
+    """Create temporary parquet files for testing."""
+    tmp_path = tmp_path_factory.mktemp("dictionary_files", numbered=False)
+    path = os.path.join(tmp_path, "group", "name", "year=2021", "month=5", "t1.parquet")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    (
+        pl.DataFrame()
+        .with_columns(
+            pl.int_range(PQ_MAX_INT).sample(PQ_NUM_ROWS, with_replacement=True).alias("int_col"),
+            pl.lit("strings").alias("string_col"),
+            pl.lit(True).alias("bool_col"),
+        )
+        .write_parquet(path)
+    )
+
+    yield str(tmp_path)
+    shutil.rmtree(tmp_path)
+
+
+@patch("odin.generate.data_dictionary.dictionary.list_objects", mock_list_objects)
+@patch("odin.generate.data_dictionary.dictionary.list_partitions", mock_list_partitions)
+def test_generate_dictionary(pq_file):
+    """Test generate_dictionary function"""
+    expected_dictionary = [
+        {
+            "child_files": [
+                f"{pq_file}/group/name/year=2021/month=5/t1.parquet",
+            ],
+            "dataset_group": "group",
+            "dataset_name": "name",
+            "dataset_path": f"{pq_file}/group/name",
+            "schema": [
+                {
+                    "column_name": "int_col",
+                    "column_type": "int64",
+                    "is_partition": False,
+                },
+                {
+                    "column_name": "string_col",
+                    "column_type": "large_string",
+                    "is_partition": False,
+                },
+                {
+                    "column_name": "bool_col",
+                    "column_type": "bool",
+                    "is_partition": False,
+                },
+                {
+                    "column_name": "year",
+                    "column_type": "int32",
+                    "is_partition": True,
+                },
+                {
+                    "column_name": "month",
+                    "column_type": "int32",
+                    "is_partition": True,
+                },
+            ],
+            "size_mb": 0,
+        },
+    ]
+    with patch("odin.generate.data_dictionary.dictionary.ODIN_ROOT", pq_file):
+        data_dictionary = [d for d in generate_dictionary(pq_file)]
+        assert data_dictionary == expected_dictionary


### PR DESCRIPTION
This change adds a job to automatically create data dictionary exports for all parquet datasets in the SPRINGBOARD/ODIN_DATA partition.

This is just an initial draft of the data dictionary format and will likely change as needs arise.