### PR TITLE
fix: S&B AFC API tableinfos schema change

### DIFF
--- a/tests/ingestion/afc/afc_archive_test.py
+++ b/tests/ingestion/afc/afc_archive_test.py
@@ -1,11 +1,17 @@
+import os
+import re
+import shutil
+from typing import Generator
 from unittest.mock import MagicMock
 from unittest.mock import patch
 from unittest.mock import call
 
 import polars as pl
+import pytest
 
 from odin.ingestion.afc.afc_archive import ArchiveAFCAPI
 from odin.ingestion.afc.afc_archive import make_pl_schema
+from odin.ingestion.afc.afc_archive import verify_downloads
 
 
 @patch.object(ArchiveAFCAPI, "download_csv")
@@ -14,13 +20,16 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
     """Test load_sids method of ArchiveAFCAPI"""
     disk_free.return_value = 99
     job = ArchiveAFCAPI("test_table")
-    test_schema = [
-        {"column_name": "col1", "data_type": "bigint"},
-        {"column_name": "col2", "data_type": "integer"},
-        {"column_name": "col3", "data_type": "varchar"},
-        {"column_name": "col4", "data_type": "timestamp with time zone"},
-        {"column_name": "col5", "data_type": "varchar"},
-    ]
+    test_schema = {
+        "type": "static",
+        "table_infos": [
+            {"column_name": "col1", "data_type": "bigint"},
+            {"column_name": "col2", "data_type": "integer"},
+            {"column_name": "col3", "data_type": "varchar"},
+            {"column_name": "col4", "data_type": "timestamp with time zone"},
+            {"column_name": "col5", "data_type": "varchar"},
+        ],
+    }
     expected_schema = pl.Schema(
         {
             "col1": pl.Int64(),
@@ -107,3 +116,62 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
     job.load_sids()
     dl_csv.assert_called_once_with([{"jobId": 1001, "dataCount": 500}])
     dl_csv.reset_mock()
+
+
+@pytest.fixture(scope="module")
+def csv_file(tmp_path_factory) -> Generator[str]:
+    """Create temporary csv file for testing."""
+    tmp_path = tmp_path_factory.mktemp("csv_verify_downloads", numbered=False)
+    path = os.path.join(tmp_path, "1.csv")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    data = [
+        {"sid": 1, "value": "sid_1"},
+        {"sid": 2, "value": "sid_2"},
+        {"sid": 2, "value": "sid_2"},
+        {"sid": 3, "value": "sid_3"},
+        {"sid": 3, "value": "sid_3"},
+        {"sid": 3, "value": "sid_3"},
+    ]
+    (pl.DataFrame(data).write_csv(path, include_header=True))
+
+    yield str(tmp_path)
+    shutil.rmtree(tmp_path)
+
+
+def test_verify_downloads(csv_file):
+    """Test verify_downloads function of AFC archive process."""
+    csv_schema = pl.Schema({"sid": pl.Int64(), "value": pl.String()})
+
+    download_jobs = [
+        {"jobId": 1, "dataCount": 1},
+        {"jobId": 2, "dataCount": 2},
+        {"jobId": 3, "dataCount": 3},
+    ]
+    verify_downloads(csv_file, csv_schema, download_jobs)
+
+    download_jobs = [
+        {"jobId": 1, "dataCount": 1},
+        {"jobId": 2, "dataCount": 2},
+    ]
+    assert_re = re.escape("SID(s) from `stagetable` not in `count` endpoint:(3)")
+    with pytest.raises(AssertionError, match=assert_re):
+        verify_downloads(csv_file, csv_schema, download_jobs)
+
+    download_jobs = [
+        {"jobId": 1, "dataCount": 1},
+        {"jobId": 2, "dataCount": 2},
+        {"jobId": 3, "dataCount": 3},
+        {"jobId": 4, "dataCount": 4},
+    ]
+    assert_re = re.escape("SID(s) from `count` not in `stagetable` endpoint:(4)")
+    with pytest.raises(AssertionError, match=assert_re):
+        verify_downloads(csv_file, csv_schema, download_jobs)
+
+    download_jobs = [
+        {"jobId": 1, "dataCount": 10},
+        {"jobId": 2, "dataCount": 2},
+        {"jobId": 3, "dataCount": 3},
+    ]
+    assert_re = re.escape("record counts from `count` and `stagetable` not equal:(sid 1: 10!=1)")
+    with pytest.raises(AssertionError, match=assert_re):
+        verify_downloads(csv_file, csv_schema, download_jobs)


### PR DESCRIPTION
This change updates the ArchiveAFCAPI Job to handle changes to the response structure of the `tableinfos` endpoint of the AFC API.

The API now returns a list of single element dictionaries with the schema of APITableInfo.

```
[
  {
    "v_card": {
      "type": "static",
      "frequency": "PT24H",
      "remarks": "Legacy: Each single (physical) card within the system has one entry in this table.",
      "table_infos": [
        ...
      ]
    }
  },
  {
    "v_deviceclass": {
      "type": "static",
      "frequency": "PT24H",
      "remarks": "Deviceclass table is mandatory and contains information about the device classification",
      "table_infos": [
        {
          "column_name": "sid",
          "ordinal_position": 1,
          "is_nullable": "YES",
          "data_type": "bigint",
          "max_length": 64,
          "default_value": null,
          "remarks": null
        }
...
```