### PR TITLE
feat: process seperate S&B AFC API table types

### DIFF
--- a/src/odin/utils/aws/s3.py
+++ b/src/odin/utils/aws/s3.py
@@ -290,6 +290,8 @@ def delete_objects(objects: List[str]):
 
     :return: list of objects that failed to delete
     """
+    if len(objects) == 0:
+        return
     logger = ProcessLog("delete_objects", object_count=len(objects))
 
     thread_workers = thread_cpus()


### PR DESCRIPTION
S&B API is now providing a `type` value from the `tableinfos` endpoint.

The `type` can either be "static" or "transactional".

"static" indicates the table should only ever have 1 sid/jobId value at a time and performs a full truncate and reload for any new data.

"transactional" is an incremental (append-only) data loading strategy.

The `ArchiveAFCAPI` Job previously assumed all tables operated as "transactional" this change updates the process to also handle "static" table types. 