### PR TITLE
feat: add cubic report material views to duckdb

### DIFF
--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -91,6 +91,7 @@ def cdc_to_fact(
 
     :return: Tuple[new INSERT df, new UPDATE df, new DELETE df]
     """
+    cdc_df = cdc_df.drop("snapshot", strict=False)
     insert_df = pl.concat(
         [insert_df, cdc_df.filter(pl.col("header__change_oper").eq("I"))],
         how="diagonal",
@@ -258,6 +259,7 @@ class CubicODSFact(OdinJob):
         ):
             if batch.num_rows == 0:
                 continue
+            batch = batch.drop_columns("snapshot")
             batch = batch.append_column(
                 "odin_index",
                 pa.array(list(range(odin_index, odin_index + batch.num_rows)), type=pa.int64()),

--- a/src/odin/generate/data_dictionary/cubic_reports_sql.py
+++ b/src/odin/generate/data_dictionary/cubic_reports_sql.py
@@ -102,6 +102,46 @@ COMP_B_VIEW = """
     ;
 """
 
+COMP_C_VIEW = """
+    DROP VIEW IF EXISTS cubic_reports.wc700_comp_c;
+    CREATE VIEW cubic_reports.wc700_comp_c
+    AS
+    SELECT
+        t.settlement_day_key
+        ,t.operating_day_key
+        ,rc.rider_class_name
+        ,fp.fare_prod_name
+        ,t.service_type_id
+        ,t.fare_rule_description
+        ,t.recovery_txn_type
+        ,sum(t.minimum_fare_charge) / 100 AS recovery_calculation_amount
+    FROM
+        cubic_ods.edw_farerev_recovery_txn t
+    LEFT JOIN
+        cubic_ods.edw_rider_class_dimension rc
+        ON
+            rc.rider_class_id = t.rider_class_id
+    LEFT JOIN
+        cubic_ods.edw_fare_product_dimension fp
+        ON
+            fp.fare_prod_key = t.fare_prod_key
+    WHERE
+        fp.monetary_inst_type_id = 2
+        AND t.minimum_fare_charge IS NOT NULL
+    GROUP BY
+        t.operating_day_key
+        ,t.settlement_day_key
+        ,t.service_type_id
+        ,rc.rider_class_name
+        ,fp.fare_prod_name
+        ,t.fare_rule_description
+        ,t.recovery_txn_type
+    ORDER BY
+        operating_day_key desc
+        ,settlement_day_key desc
+    ;
+"""
+
 
 COMP_D_VIEW = """
     DROP VIEW IF EXISTS cubic_reports.wc700_comp_d;
@@ -140,4 +180,124 @@ COMP_D_VIEW = """
         ps.operating_day_key desc
         ,ps.settlement_day_key desc
     ;
+"""
+
+
+LATE_TAP_ADJUSTMENT = """
+    SELECT
+        s.settlement_day_key
+        ,s.operating_day_key
+        ,u.patron_trip_id
+        ,u.trip_price_count
+        ,tp.is_reversal
+        ,u.token_id
+        ,s.purse_load_id
+        ,-tp.stored_value / 100 AS uncollectible_amount
+        ,tp.transaction_dtm
+        ,u.transit_account_id
+        ,tm.travel_mode_name,
+    FROM
+        cubic_ods.edw_sale_transaction s
+    JOIN
+        cubic_ods.edw_trip_payment tp
+        ON
+            tp.purse_load_id = s.purse_load_id
+    JOIN
+        cubic_ods.edw_patron_trip t
+        ON
+            t.patron_trip_id = tp.patron_trip_id
+    JOIN
+        cubic_ods.edw_use_transaction u
+        ON
+            u.patron_trip_id = tp.patron_trip_id
+            AND u.trip_price_count = tp.trip_price_count
+    LEFT JOIN
+        cubic_ods.edw_transaction_history en
+        ON
+            en.dw_transaction_id = t.dw_entry_txn_id
+    LEFT JOIN
+        cubic_ods.edw_travel_mode_dimension tm
+        ON
+            tm.travel_mode_id = en.travel_mode_id
+    WHERE
+        s.sale_type_key = 26
+        AND u.value_changed <> 0
+        AND
+        (
+            (
+                tp.je_is_fare_adjustment = 0
+                AND u.ride_type_key <> 24
+                AND tp.is_reversal = 1
+                AND u.fare_due < 0
+            )
+            OR
+            (
+                tp.je_is_fare_adjustment = 0
+                AND u.ride_type_key <> 24
+                AND tp.is_reversal = 0
+                AND u.fare_due > 0
+            )
+            OR (tp.je_is_fare_adjustment = 1 AND u.ride_type_key = 24)
+        )
+    ORDER BY
+        s.operating_day_key desc
+        ,s.settlement_day_key desc
+"""
+
+
+COMP_B_ADDENDUM = """
+    SELECT
+        ut.dw_transaction_id
+        ,ut.transit_account_id
+        ,ut.operating_day_key as operating_date
+        ,ut.posting_day_key as posting_date
+        ,ut.settlement_day_key as settlement_date
+        ,ut.transaction_dtm
+        ,th.transit_mode_name
+        ,ut.patron_trip_id
+        ,tr.fare_rule_description
+        ,ut.transfer_sequence_nbr
+        ,cd.bin
+        ,-(tp.bankcard_value
+            + case when tp.bankcard_payment_id is not null then tp.uncollectible_amount else 0 end
+            + case when s.purse_load_id is not null then tp.stored_value else 0 end
+        ) as fare_revenue
+        ,case when ut.transfer_sequence_nbr > 0 and ut.fare_due <> 0 then 'Transfer' else null end
+        as extension_charge_reason
+        ,ut.retrieval_ref_nbr
+    FROM
+        cubic_ods.edw_use_transaction ut
+    JOIN cubic_ods.edw_patron_trip tr
+        ON tr.patron_trip_id = ut.patron_trip_id AND tr.source = ut.source
+    JOIN cubic_ods.edw_trip_payment tp
+        ON
+            tp.patron_trip_id = ut.patron_trip_id
+            AND tp.source = ut.source
+            AND tp.trip_price_count = ut.trip_price_count
+    JOIN cubic_ods.edw_card_dimension cd
+        ON cd.card_key = ut.card_key
+    LEFT JOIN cubic_ods.edw_sale_transaction s
+        ON s.purse_load_id = tp.purse_load_id
+    LEFT JOIN cubic_ods.edw_transaction_history th
+        ON th.dw_transaction_id = ut.dw_transaction_id
+    WHERE
+        s.sale_type_key = 26
+        and (
+                (
+                    tp.journal_entry_type_id <> 131
+                    AND tp.is_reversal = 1
+                    AND ut.txn_status_key in (36, 59)
+                )
+                or (
+                    tp.journal_entry_type_id <> 131
+                    AND tp.is_reversal = 0
+                    AND ut.txn_status_key not in (36, 59, 50)
+                )
+                or (tp.journal_entry_type_id = 131 and ut.ride_type_key = 24)
+            )
+        and (
+            ut.bankcard_payment_value <> 0
+            or ut.uncollectible_amount <> 0
+            or ut.value_changed <> 0
+        )
 """

--- a/src/odin/utils/locations.py
+++ b/src/odin/utils/locations.py
@@ -22,6 +22,7 @@ CUBIC_QLIK_IGNORED = f"{ODIN_ARCHIVE}/cubic_qlik/ignored"
 
 # CUBIC ODS FACT
 CUBIC_ODS_FACT_DATA = f"{ODIN_DATA}/cubic_ods"
+CUBIC_ODS_REPORTS = f"{ODIN_DATA}/cubic_reports"
 
 # AFC
 AFC_DATA = f"{ODIN_DATA}/afc/api"


### PR DESCRIPTION
This change adds a few new reports to the `cubic_reports` schema of the duckdb file.

Some of the reports are "material views" that are pre-compiled and saved to S3 to avoid long query times.