### PR TITLE
feat: S&B updated API endpoints

### DIFF
--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -369,7 +369,7 @@ class CubicODSFact(OdinJob):
                     start_odin_index, start_odin_index + insert_df.height, dtype=pl.Int64()
                 ).alias("odin_index"),
                 pl.lit(self.history_snapshot, dtype=pl.String()).alias("odin_snapshot"),
-            ).drop(self.history_drop_columns)
+            ).drop(self.history_drop_columns, strict=False)
             if "edw_inserted_dtm" in insert_df.columns:
                 insert_df = insert_df.with_columns(
                     pl.coalesce(pl.col("edw_inserted_dtm").dt.strftime("%Y"), 0)
@@ -379,7 +379,7 @@ class CubicODSFact(OdinJob):
 
         drop_indices = pl.Series("odin_index", [], pl.Int64())
         if update_df.height > 0:
-            update_df = update_df.drop(self.history_drop_columns)
+            update_df = update_df.drop(self.history_drop_columns, strict=False)
             mod_cast, orig_cast = polars_decimal_as_string(update_df.select(keys))
             s3_update_df = ds_batched_join(fact_ds, update_df, keys, self.batch_size)
             if "odin_year" in s3_update_df.columns:

--- a/src/odin/generate/data_dictionary/duck_db.py
+++ b/src/odin/generate/data_dictionary/duck_db.py
@@ -33,7 +33,7 @@ READ_PQ = "read_parquet('$s3_path/**/*.parquet')"
 dataset_views = [
     ViewBuilder(
         s3_prefix=os.path.join(DATA_SPRINGBOARD, AFC_DATA),
-        schema="sb",
+        schema="sb_api",
         template=Template(f"{DROP_VIEW} CREATE VIEW $schema.$table AS SELECT * FROM {READ_PQ};"),
     ),
     ViewBuilder(

--- a/src/odin/migrate/migrations/odin-prod/0004.py
+++ b/src/odin/migrate/migrations/odin-prod/0004.py
@@ -1,0 +1,20 @@
+import os
+
+from odin.utils.aws.s3 import list_objects
+from odin.utils.aws.s3 import delete_objects
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.locations import AFC_DATA
+
+
+def migration() -> None:
+    """
+    ODIN PROD Migration 0004.
+
+    June 2, 2025
+
+    This migration is to reset S&B API files because of large changes to AFC API endpoints.
+
+    1. Delete all parquet files from S&B API prefix.
+    """
+    sb_prefix = os.path.join(DATA_SPRINGBOARD, AFC_DATA)
+    delete_objects([obj.path for obj in list_objects(sb_prefix)])

--- a/tests/ingestion/afc/afc_archive_test.py
+++ b/tests/ingestion/afc/afc_archive_test.py
@@ -16,10 +16,10 @@ from odin.ingestion.afc.afc_archive import verify_downloads
 from odin.utils.aws.s3 import S3Object
 
 
-@patch.object(ArchiveAFCAPI, "download_csv")
+@patch.object(ArchiveAFCAPI, "download_json")
 @patch("odin.ingestion.afc.afc_archive.disk_free_pct")
-def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
-    """Test load_sids method of ArchiveAFCAPI"""
+def test_load_job_ids(disk_free: MagicMock, dl_csv: MagicMock):
+    """Test load_job_ids method of ArchiveAFCAPI"""
     disk_free.return_value = 99
     job = ArchiveAFCAPI("test_table")
     test_schema = {
@@ -45,7 +45,7 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
     assert job.schema == expected_schema
 
     # Test jobId skipping
-    job.pq_sid = 1000
+    job.pq_job_id = 1000
     job.job_ids = [
         {"jobId": 1, "dataCount": 1},
         {"jobId": 2, "dataCount": 1},
@@ -59,7 +59,7 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
         {"jobId": 1000, "dataCount": 1},
         {"jobId": 1001, "dataCount": 1},
     ]
-    job.load_sids()
+    job.load_job_ids()
     dl_csv.assert_called_once_with([{"jobId": 1001, "dataCount": 1}])
     dl_csv.reset_mock()
 
@@ -70,7 +70,7 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
         {"jobId": 1001, "dataCount": 1_000_000},
         {"jobId": 1002, "dataCount": 500},
     ]
-    job.load_sids()
+    job.load_job_ids()
     dl_csv.assert_has_calls(
         [
             call([{"jobId": 1001, "dataCount": 1_000_000}]),
@@ -86,7 +86,7 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
         {"jobId": 1001, "dataCount": 500},
         {"jobId": 1002, "dataCount": 500},
     ]
-    job.load_sids()
+    job.load_job_ids()
     dl_csv.assert_called_once_with(
         [
             {"jobId": 1001, "dataCount": 500},
@@ -102,7 +102,7 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
         {"jobId": 1004, "dataCount": 500},
         {"jobId": 1003, "dataCount": 300},
     ]
-    job.load_sids()
+    job.load_job_ids()
     dl_csv.assert_called_once_with(
         [
             {"jobId": 1001, "dataCount": 500},
@@ -115,7 +115,7 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
 
     # Test disk_free_pct hit
     disk_free.return_value = 50
-    job.load_sids()
+    job.load_job_ids()
     dl_csv.assert_called_once_with([{"jobId": 1001, "dataCount": 500}])
     dl_csv.reset_mock()
 
@@ -124,17 +124,17 @@ def test_load_sids(disk_free: MagicMock, dl_csv: MagicMock):
 def csv_file(tmp_path_factory) -> Generator[str]:
     """Create temporary csv file for testing."""
     tmp_path = tmp_path_factory.mktemp("csv_verify_downloads", numbered=False)
-    path = os.path.join(tmp_path, "1.csv")
+    path = os.path.join(tmp_path, "1.json")
     os.makedirs(os.path.dirname(path), exist_ok=True)
     data = [
-        {"sid": 1, "value": "sid_1"},
-        {"sid": 2, "value": "sid_2"},
-        {"sid": 2, "value": "sid_2"},
-        {"sid": 3, "value": "sid_3"},
-        {"sid": 3, "value": "sid_3"},
-        {"sid": 3, "value": "sid_3"},
+        {"job_id": 1, "value": "sid_1"},
+        {"job_id": 2, "value": "sid_2"},
+        {"job_id": 2, "value": "sid_2"},
+        {"job_id": 3, "value": "sid_3"},
+        {"job_id": 3, "value": "sid_3"},
+        {"job_id": 3, "value": "sid_3"},
     ]
-    (pl.DataFrame(data).write_csv(path, include_header=True))
+    (pl.DataFrame(data).write_ndjson(path))
 
     yield str(tmp_path)
     shutil.rmtree(tmp_path)
@@ -142,7 +142,7 @@ def csv_file(tmp_path_factory) -> Generator[str]:
 
 def test_verify_downloads(csv_file):
     """Test verify_downloads function of AFC archive process."""
-    csv_schema = pl.Schema({"sid": pl.Int64(), "value": pl.String()})
+    csv_schema = pl.Schema({"job_id": pl.Int64(), "value": pl.String()})
 
     download_jobs = [
         {"jobId": 1, "dataCount": 1},
@@ -155,7 +155,7 @@ def test_verify_downloads(csv_file):
         {"jobId": 1, "dataCount": 1},
         {"jobId": 2, "dataCount": 2},
     ]
-    assert_re = re.escape("SID(s) from `stagetable` not in `count` endpoint:(3)")
+    assert_re = re.escape("job_id(s) from `stagetable` not in `count` endpoint:(3)")
     with pytest.raises(AssertionError, match=assert_re):
         verify_downloads(csv_file, csv_schema, download_jobs)
 
@@ -165,7 +165,7 @@ def test_verify_downloads(csv_file):
         {"jobId": 3, "dataCount": 3},
         {"jobId": 4, "dataCount": 4},
     ]
-    assert_re = re.escape("SID(s) from `count` not in `stagetable` endpoint:(4)")
+    assert_re = re.escape("job_id(s) from `count` not in `stagetable` endpoint:(4)")
     with pytest.raises(AssertionError, match=assert_re):
         verify_downloads(csv_file, csv_schema, download_jobs)
 
@@ -174,7 +174,7 @@ def test_verify_downloads(csv_file):
         {"jobId": 2, "dataCount": 2},
         {"jobId": 3, "dataCount": 3},
     ]
-    assert_re = re.escape("record counts from `count` and `stagetable` not equal:(sid 1: 10!=1)")
+    assert_re = re.escape("record counts from `count` and `stagetable` not equal:(job_id 1: 10!=1)")
     with pytest.raises(AssertionError, match=assert_re):
         verify_downloads(csv_file, csv_schema, download_jobs)
 
@@ -188,16 +188,17 @@ def test_sync_parquet_bad_type(
 ):
     """Test sync_parquet method of ArchiveAFCAPI for bad table type"""
     data = [
-        {"sid": 1, "value": "sid_1"},
-        {"sid": 1, "value": "sid_1"},
-        {"sid": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
     ]
-    pl.DataFrame(data).write_csv(os.path.join(tmpdir, "1.csv"), include_header=True)
+    pl.DataFrame(data).write_ndjson(os.path.join(tmpdir, "1.json"))
 
     job = ArchiveAFCAPI("test_table")
     job.tmpdir = tmpdir
-    job.schema = pl.Schema({"sid": pl.Int64(), "value": pl.String()})
+    job.schema = pl.Schema({"job_id": pl.Int64(), "value": pl.String()})
     job.table_type = "not_static"
+    job.ts_cols = []
     job.export_folder = ""
     ls_obj.return_value = []
 
@@ -219,16 +220,17 @@ def test_sync_parquet_static(
     """Test sync_parquet method of ArchiveAFCAPI for static table type"""
     export = "bucket"
     data = [
-        {"sid": 1, "value": "sid_1"},
-        {"sid": 1, "value": "sid_1"},
-        {"sid": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
     ]
-    pl.DataFrame(data).write_csv(os.path.join(tmpdir, "1.csv"), include_header=True)
+    pl.DataFrame(data).write_ndjson(os.path.join(tmpdir, "1.json"))
 
     job = ArchiveAFCAPI("test_table")
     job.tmpdir = tmpdir
-    job.schema = pl.Schema({"sid": pl.Int64(), "value": pl.String()})
+    job.schema = pl.Schema({"job_id": pl.Int64(), "value": pl.String()})
     job.table_type = "static"
+    job.ts_cols = []
     job.export_folder = export
     ls_obj.return_value = [S3Object(path="delete_me", size_bytes=0, last_modified=datetime.now())]
     export_file = os.path.join(tmpdir, export, "table_001.parquet")
@@ -240,16 +242,16 @@ def test_sync_parquet_static(
     os.unlink(export_file)
 
     data = [
-        {"sid": 1, "value": "sid_1"},
-        {"sid": 1, "value": "sid_1"},
-        {"sid": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
     ]
-    pl.DataFrame(data).write_csv(os.path.join(tmpdir, "1.csv"), include_header=True)
+    pl.DataFrame(data).write_ndjson(os.path.join(tmpdir, "1.json"))
     data = [
-        {"sid": 2, "value": "sid_2"},
-        {"sid": 2, "value": "sid_2"},
+        {"job_id": 2, "value": "sid_2"},
+        {"job_id": 2, "value": "sid_2"},
     ]
-    pl.DataFrame(data).write_csv(os.path.join(tmpdir, "2.csv"), include_header=True)
+    pl.DataFrame(data).write_ndjson(os.path.join(tmpdir, "2.json"))
     with pytest.raises(AssertionError):
         job.sync_parquet()
 
@@ -264,21 +266,22 @@ def test_sync_parquet_transactional(
     """Test sync_parquet method of ArchiveAFCAPI for transactional table type"""
     export = "bucket"
     data = [
-        {"sid": 1, "value": "sid_1"},
-        {"sid": 1, "value": "sid_1"},
-        {"sid": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
+        {"job_id": 1, "value": "sid_1"},
     ]
-    pl.DataFrame(data).write_csv(os.path.join(tmpdir, "1.csv"), include_header=True)
+    pl.DataFrame(data).write_ndjson(os.path.join(tmpdir, "1.json"))
 
     data = [
-        {"sid": 0, "value": "sid_0"},
+        {"job_id": 0, "value": "sid_0"},
     ]
     pl.DataFrame(data).write_parquet(os.path.join(tmpdir, "temp_.parquet"))
 
     job = ArchiveAFCAPI("test_table")
     job.tmpdir = tmpdir
-    job.schema = pl.Schema({"sid": pl.Int64(), "value": pl.String()})
+    job.schema = pl.Schema({"job_id": pl.Int64(), "value": pl.String()})
     job.table_type = "transactional"
+    job.ts_cols = []
     job.export_folder = export
     ls_obj.return_value = [
         S3Object(path="temp_.parquet", size_bytes=0, last_modified=datetime.now())


### PR DESCRIPTION
This change implements changes to the S&B AFC API endpoints, which include the following:
 - `sid` column name changed to `job_id`
 - `identity_value` column added to all datasets
 - endpoint parameter names changed from `sidFrom` -> `jobIdFrom` & `sidTo` -> `jobIdTo`

This change also updates the default ingestion format from csv to ndjson files.

Fix .drop call in Ods Fact job to not error if some columns are not available to drop. 