### PR TITLE
fix: TRANSACTION_HISTORY Archive OOM

### DIFF
--- a/src/odin/ingestion/qlik/cubic_archive.py
+++ b/src/odin/ingestion/qlik/cubic_archive.py
@@ -13,6 +13,8 @@ from typing import Optional
 from itertools import batched
 from concurrent.futures import ThreadPoolExecutor
 
+import psutil
+
 from odin.utils.logger import ProcessLog
 from odin.utils.runtime import sigterm_check
 from odin.job import OdinJob
@@ -285,7 +287,9 @@ class ArchiveCubicQlikTable(OdinJob):
                             cdc_paths += written
                             self.archive_objects += archive
                         # create maximum of 10 parquet files in one event loop.
-                        if len(cdc_paths) > 9:
+                        # or memory usage getting high
+                        # TODO: monitor this memory threshold make sure performance is ok
+                        if len(cdc_paths) > 9 or psutil.virtual_memory().percent > 60:
                             break
                     if cdc_bytes > 0:
                         written, archive = cdc_csv_to_parquet(

--- a/tests/utils/parquet_test.py
+++ b/tests/utils/parquet_test.py
@@ -5,6 +5,7 @@ from typing import Generator
 from pathlib import Path
 
 import polars as pl
+import pyarrow as pa
 import pyarrow.dataset as pd
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
@@ -103,11 +104,34 @@ def test_ds_from_path(pq_files) -> None:
     """Test ds_from_path parquet utility."""
     ds = ds_from_path(pq_files[0])
     assert isinstance(ds, pd.UnionDataset)
+    expected_scehma = pa.schema(
+        (
+            ("col1", pa.int64()),
+            ("col2", pa.int64()),
+            ("file", pa.string()),
+            ("year", pa.int32()),
+        )
+    )
+    assert ds.schema.equals(expected_scehma)
 
     ds = ds_from_path(pq_files)
     assert isinstance(ds, pd.UnionDataset)
     assert ds.count_rows() == PQ_NUM_ROWS * len(pq_files)
     assert len(ds.schema.names) == 9
+    expected_scehma = pa.schema(
+        (
+            ("col1", pa.int64()),
+            ("col2", pa.int64()),
+            ("file", pa.string()),
+            ("year", pa.int32()),
+            ("col3", pa.int64()),
+            ("col4", pa.int64()),
+            ("col5", pa.int64()),
+            ("col6", pa.int64()),
+            ("col7", pa.large_string()),
+        )
+    )
+    assert ds.schema.equals(expected_scehma)
 
 
 def test_ds_column_min_max(pq_files) -> None:


### PR DESCRIPTION
This change is attempting to fix OOM errors being thowing by the ArchiveCubicQlikTable process for the TRANSACTION_HISTORY table.

This will stop generating CDC parquet files if a memory threshold is reached. This threshold should be reviewed in the future to confirm it had no negative effects on other parts of the pipeline.

Asana Task: https://app.asana.com/1/15492006741476/project/1208949713596462/task/1210654078793430