### PR TITLE
fix: ODSFact TRANSACTION_HISTORY OOM

### DIFF
--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -191,7 +191,7 @@ class CubicODSFact(OdinJob):
         frag: pd.ParquetFileFragment
         for frag in self.history_ds.get_fragments():
             history_ds_groups += frag.num_row_groups
-        self.batch_size = max(5000, int(history_ds_rows / (20 * history_ds_groups)))
+        self.batch_size = max(5000, int(history_ds_rows / (4 * history_ds_groups)))
 
         try:
             self.fact_snapshot = str(fast_last_mod_ds_max(self.s3_export, "odin_snapshot"))

--- a/tests/utils/parquet_test.py
+++ b/tests/utils/parquet_test.py
@@ -21,7 +21,7 @@ from odin.utils.parquet import _pq_find_part_offset
 from odin.utils.parquet import ds_metadata_limit_k_sorted
 from odin.utils.parquet import pq_path_partitions
 from odin.utils.parquet import row_group_column_stats
-
+from odin.utils.parquet import ds_batched_join
 
 PQ_NUM_ROWS = 500_000
 PQ_MAX_INT = 50_000
@@ -260,3 +260,18 @@ def test_ds_metadata_limit_k_sorted(pq_files) -> None:
     assert df.shape == (PQ_NUM_ROWS, 9)
     assert df.get_column("col1")[0] == 0
     assert df.get_column("col1")[-1] == PQ_MAX_INT - 1
+
+
+def test_ds_batched_join(pq_files) -> None:
+    """
+    Test ds_batched_join parquet utility.
+
+    Limited scope here, hopefully expand.
+    """
+    ds = ds_from_path(pq_files)
+
+    match_frame = pl.DataFrame([{"col7": "single_value"}])
+
+    joined_frame = ds_batched_join(ds, match_frame, keys=["col7"], batch_size=10_000)
+
+    assert joined_frame.shape == (PQ_NUM_ROWS, 9)


### PR DESCRIPTION
For the last few days, Odin has been throwing OOM errors when attempting to process the EDW.TRANSACTION_HISTORY table for the ODSFACT job.

This error was traced back to the `ds_batched_join` function, which is designed to join a polars dataframe to a very large parquet dataset in a memory constrained environment. Unfortunately, the implementation was not as memory constrained as originally thought.

In this instance, the JOIN operations was matching to a very small number of records from almost every partition across the whole dataset. In converting a pyarrow RecordBatch to a polars Dataframe, for each JOIN match, the memory allocation from each matched RecordBatch was being leaked as the dataset was iterated through.

This conversion to Polars is only required for JOIN operations on key columns that may contain NULL values. If no NULL values need to be JOIN'ed on, the JOIN operation can occur entirely in pyarrow (using Tables) and the memory leak does not occur. The NON NULL operation is the primary JOIN operation that occurs, so the Polars conversion remains for the small subset of data needing this functionality.

We'll test this on DEV to make sure all the datasets are able to execute JOIN operations correctly before deploying to PROD.