### PR TITLE
feat: update ODIN DATA paths

### DIFF
--- a/src/odin/migrate/migrations/odin-dev/0008.py
+++ b/src/odin/migrate/migrations/odin-dev/0008.py
@@ -1,0 +1,53 @@
+import os
+
+from odin.utils.aws.s3 import list_objects
+from odin.utils.aws.s3 import _rename_objects
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.locations import ODIN_DATA
+from odin.utils.locations import CUBIC_QLIK_DATA
+from odin.utils.locations import CUBIC_ODS_FACT_DATA
+from odin.utils.locations import CUBIC_ODS_REPORTS
+from odin.utils.locations import AFC_DATA
+from odin.utils.locations import AFC_RESTRICTED
+
+
+def migration() -> None:
+    """
+    ODIN DEV Migration 0008.
+
+    July 17, 2025
+
+    This migration changes the dataset naming convention of several ODIN result sets:
+
+    - odin/data/cubic_qlik          -> odin/data/cubic/ods_history
+    - odin/data/cubic_ods           -> odin/data/cubic/ods
+    - odin/data/cubic_reports       -> odin/data/cubic/reports
+    - odin/data/afc/api             -> odin/data/sb/api
+    - odin/data/afc/sb_restricted   -> doin/data/sb/restricted
+
+    """
+    prefix_jobs = [
+        (
+            os.path.join(DATA_SPRINGBOARD, ODIN_DATA, "cubic_qlik", ""),
+            os.path.join(DATA_SPRINGBOARD, CUBIC_QLIK_DATA, ""),
+        ),
+        (
+            os.path.join(DATA_SPRINGBOARD, ODIN_DATA, "cubic_ods", ""),
+            os.path.join(DATA_SPRINGBOARD, CUBIC_ODS_FACT_DATA, ""),
+        ),
+        (
+            os.path.join(DATA_SPRINGBOARD, ODIN_DATA, "cubic_reports", ""),
+            os.path.join(DATA_SPRINGBOARD, CUBIC_ODS_REPORTS, ""),
+        ),
+        (
+            os.path.join(DATA_SPRINGBOARD, ODIN_DATA, "afc/api", ""),
+            os.path.join(DATA_SPRINGBOARD, AFC_DATA, ""),
+        ),
+        (
+            os.path.join(DATA_SPRINGBOARD, ODIN_DATA, "afc/sb_restricted", ""),
+            os.path.join(DATA_SPRINGBOARD, AFC_RESTRICTED, ""),
+        ),
+    ]
+    for old, new in prefix_jobs:
+        rename_map = [(o.path, o.path.replace(old, new)) for o in list_objects(old)]
+        _rename_objects(rename_map)

--- a/src/odin/migrate/migrations/odin-prod/0009.py
+++ b/src/odin/migrate/migrations/odin-prod/0009.py
@@ -1,0 +1,53 @@
+import os
+
+from odin.utils.aws.s3 import list_objects
+from odin.utils.aws.s3 import _rename_objects
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.locations import ODIN_DATA
+from odin.utils.locations import CUBIC_QLIK_DATA
+from odin.utils.locations import CUBIC_ODS_FACT_DATA
+from odin.utils.locations import CUBIC_ODS_REPORTS
+from odin.utils.locations import AFC_DATA
+from odin.utils.locations import AFC_RESTRICTED
+
+
+def migration() -> None:
+    """
+    ODIN PROD Migration 0009.
+
+    July 17, 2025
+
+    This migration changes the dataset naming convention of several ODIN result sets:
+
+    - odin/data/cubic_qlik          -> odin/data/cubic/ods_history
+    - odin/data/cubic_ods           -> odin/data/cubic/ods
+    - odin/data/cubic_reports       -> odin/data/cubic/reports
+    - odin/data/afc/api             -> odin/data/sb/api
+    - odin/data/afc/sb_restricted   -> doin/data/sb/restricted
+
+    """
+    prefix_jobs = [
+        (
+            os.path.join(DATA_SPRINGBOARD, ODIN_DATA, "cubic_qlik", ""),
+            os.path.join(DATA_SPRINGBOARD, CUBIC_QLIK_DATA, ""),
+        ),
+        (
+            os.path.join(DATA_SPRINGBOARD, ODIN_DATA, "cubic_ods", ""),
+            os.path.join(DATA_SPRINGBOARD, CUBIC_ODS_FACT_DATA, ""),
+        ),
+        (
+            os.path.join(DATA_SPRINGBOARD, ODIN_DATA, "cubic_reports", ""),
+            os.path.join(DATA_SPRINGBOARD, CUBIC_ODS_REPORTS, ""),
+        ),
+        (
+            os.path.join(DATA_SPRINGBOARD, ODIN_DATA, "afc/api", ""),
+            os.path.join(DATA_SPRINGBOARD, AFC_DATA, ""),
+        ),
+        (
+            os.path.join(DATA_SPRINGBOARD, ODIN_DATA, "afc/sb_restricted", ""),
+            os.path.join(DATA_SPRINGBOARD, AFC_RESTRICTED, ""),
+        ),
+    ]
+    for old, new in prefix_jobs:
+        rename_map = [(o.path, o.path.replace(old, new)) for o in list_objects(old)]
+        _rename_objects(rename_map)

--- a/src/odin/utils/locations.py
+++ b/src/odin/utils/locations.py
@@ -15,15 +15,15 @@ ODIN_DICTIONARY = f"{ODIN_DATA}/dictionary"
 
 # CUBIC QLIK
 IN_QLIK_PREFIX = "cubic/ods_qlik"
-CUBIC_QLIK_DATA = f"{ODIN_DATA}/cubic_qlik"
+CUBIC_QLIK_DATA = f"{ODIN_DATA}/cubic/ods_history"
 CUBIC_QLIK_ERROR = f"{ODIN_ERROR}/cubic_qlik"
 CUBIC_QLIK_PROCESSED = f"{ODIN_ARCHIVE}/cubic_qlik/processed"
 CUBIC_QLIK_IGNORED = f"{ODIN_ARCHIVE}/cubic_qlik/ignored"
 
 # CUBIC ODS FACT
-CUBIC_ODS_FACT_DATA = f"{ODIN_DATA}/cubic_ods"
-CUBIC_ODS_REPORTS = f"{ODIN_DATA}/cubic_reports"
+CUBIC_ODS_FACT_DATA = f"{ODIN_DATA}/cubic/ods"
+CUBIC_ODS_REPORTS = f"{ODIN_DATA}/cubic/reports"
 
 # AFC
-AFC_DATA = f"{ODIN_DATA}/afc/api"
-AFC_RESTRICTED = f"{ODIN_DATA}/afc/sb_restricted"
+AFC_DATA = f"{ODIN_DATA}/sb/api"
+AFC_RESTRICTED = f"{ODIN_DATA}/sb/restricted"


### PR DESCRIPTION
This change updates/standardizes some ODIN dataset paths. When these paths were originally created, the selected paths were not fully discussed/planned.

After a review of all existing dataset paths the attached changes were selected.

These changes will be executed via S3 migration, after the migration the ODIN application should continue operating without interruption. Will be tested on DEV before deploy to PROD.

Asana task: https://app.asana.com/1/15492006741476/project/1208949713596457/task/1210413896483727