### PR TITLE
Add retry to afc filesystem op

### DIFF
--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -4,12 +4,11 @@ import json
 import sched
 import shutil
 import urllib3
+import time
 from collections import ChainMap
 from operator import itemgetter
 from pathlib import Path
-from typing import Literal
-from typing import TypedDict
-from typing import Generator
+from typing import Literal, TypedDict, Generator
 
 
 from odin.job import OdinJob
@@ -339,7 +338,14 @@ class ArchiveAFCAPI(OdinJob):
         # convert to json.gz to json, so polars can be used
         # json file should also produce more consistent disk and memory usage profiles
         with gzip.open(gz_path, mode="rb") as gz_read, open(json_path, mode="wb") as json_w:
-            shutil.copyfileobj(gz_read, json_w)
+            try:
+                shutil.copyfileobj(gz_read, json_w)
+            except EOFError:
+                # Sometimes there is a file read error on gz_path, which may be due to
+                # filesystem latency.
+                time.sleep(10)
+                shutil.copyfileobj(gz_read, json_w)
+
         os.remove(gz_path)
 
         log.complete()

--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -350,9 +350,13 @@ class ArchiveAFCAPI(OdinJob):
                 break
             except Exception as e:
                 ProcessLog(
-                        "download_json", gz_path=gz_path, json_path=json_path, retrying=retry_num,
-                        exception=str(e)
+                    "download_json",
+                    gz_path=gz_path,
+                    json_path=json_path,
+                    retrying=retry_num,
+                    exception=str(e),
                 )
+
                 time.sleep(10)
                 continue
 

--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -80,6 +80,8 @@ if os.getenv("ECS_TASK_GROUP") == "family:odin-prod":
         }
     )
 
+REQUEST_RETRIES = 3
+
 APICounts = list[dict[Literal["jobId", "dataCount"], int]]
 
 APITableSchema = list[dict[Literal["column_name", "data_type"], str]]
@@ -325,30 +327,38 @@ class ArchiveAFCAPI(OdinJob):
             "jobIdFrom": str(job_id_from),
             "jobIdTo": str(job_id_to),
         }
-        r = self.make_request(url, fields=fields, preload_content=False)
 
         json_path = os.path.join(self.tmpdir, f"{job_id_from}.json")
         gz_path = f"{json_path}.gz"
+        success = False
+        for retry_num in range(REQUEST_RETRIES):
+            r = self.make_request(url, fields=fields, preload_content=False)
 
-        # download json.gz file (as stream)
-        with open(gz_path, mode="wb") as gz_write:
-            shutil.copyfileobj(r, gz_write)
-        r.release_conn()
+            # download json.gz file (as stream)
+            with open(gz_path, mode="wb") as gz_write:
+                shutil.copyfileobj(r, gz_write)
+            r.release_conn()
 
-        # convert to json.gz to json, so polars can be used
-        # json file should also produce more consistent disk and memory usage profiles
-        with gzip.open(gz_path, mode="rb") as gz_read, open(json_path, mode="wb") as json_w:
-            try:
-                shutil.copyfileobj(gz_read, json_w)
-            except EOFError:
-                # Sometimes there is a file read error on gz_path, which may be due to
-                # filesystem latency.
-                time.sleep(10)
-                shutil.copyfileobj(gz_read, json_w)
+            # convert to json.gz to json, so polars can be used
+            # json file should also produce more consistent disk and memory usage profiles
+            with gzip.open(gz_path, mode="rb") as gz_read, open(json_path, mode="wb") as json_w:
+                try:
+                    shutil.copyfileobj(gz_read, json_w)
+                    success = True
+                except EOFError:
+                    ProcessLog(
+                        "download_json", gz_path=gz_path, json_path=json_path, retrying=retry_num
+                    )
+                    time.sleep(10)
+                    continue
 
-        os.remove(gz_path)
+            os.remove(gz_path)
+            break
 
-        log.complete()
+        if success:
+            log.complete()
+        else:
+            log.failed(IOError("Failed to download and convert JSON file."))
         verify_downloads(json_path, self.schema, download_jobs)
 
     def load_job_ids(self) -> None:

--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -332,28 +332,29 @@ class ArchiveAFCAPI(OdinJob):
         gz_path = f"{json_path}.gz"
         success = False
         for retry_num in range(REQUEST_RETRIES):
-            r = self.make_request(url, fields=fields, preload_content=False)
+            try:
+                r = self.make_request(url, fields=fields, preload_content=False)
 
-            # download json.gz file (as stream)
-            with open(gz_path, mode="wb") as gz_write:
-                shutil.copyfileobj(r, gz_write)
-            r.release_conn()
+                # download json.gz file (as stream)
+                with open(gz_path, mode="wb") as gz_write:
+                    shutil.copyfileobj(r, gz_write)
+                r.release_conn()
 
-            # convert to json.gz to json, so polars can be used
-            # json file should also produce more consistent disk and memory usage profiles
-            with gzip.open(gz_path, mode="rb") as gz_read, open(json_path, mode="wb") as json_w:
-                try:
+                # convert to json.gz to json, so polars can be used
+                # json file should also produce more consistent disk and memory usage profiles
+                with gzip.open(gz_path, mode="rb") as gz_read, open(json_path, mode="wb") as json_w:
                     shutil.copyfileobj(gz_read, json_w)
-                    success = True
-                except EOFError:
-                    ProcessLog(
-                        "download_json", gz_path=gz_path, json_path=json_path, retrying=retry_num
-                    )
-                    time.sleep(10)
-                    continue
 
-            os.remove(gz_path)
-            break
+                os.remove(gz_path)
+                success = True
+                break
+            except Exception as e:
+                ProcessLog(
+                        "download_json", gz_path=gz_path, json_path=json_path, retrying=retry_num,
+                        exception=str(e)
+                )
+                time.sleep(10)
+                continue
 
         if success:
             log.complete()

--- a/tests/ingestion/afc/afc_archive_test.py
+++ b/tests/ingestion/afc/afc_archive_test.py
@@ -10,10 +10,40 @@ from unittest.mock import call
 import polars as pl
 import pytest
 
+from odin.ingestion.afc.afc_archive import APICounts
 from odin.ingestion.afc.afc_archive import ArchiveAFCAPI
 from odin.ingestion.afc.afc_archive import make_pl_schema
 from odin.ingestion.afc.afc_archive import verify_downloads
 from odin.utils.aws.s3 import S3Object
+
+
+@patch.object(ArchiveAFCAPI, "make_request")
+@patch("shutil.copyfileobj")
+@patch("gzip.open")
+@patch("odin.ingestion.afc.afc_archive.verify_downloads")
+def test_download_json(
+    verify_downloads: MagicMock,
+    gzip_open: MagicMock,
+    copyfileobj: MagicMock,
+    make_request: MagicMock,
+):
+    """Test download_json method of ArchiveAFCAPI"""
+    job = ArchiveAFCAPI("test_table")
+    job.reset_tmpdir()
+    job.schema = None
+    mock_response = MagicMock()
+    mock_response.release_conn = lambda: None
+
+    # Require a single retry to succeed in the test.
+    make_request.side_effect = [IOError("Something happened!!"), mock_response]
+
+    test_download_jobs: APICounts = [{"jobId": 0, "dataCount": -1}, {"jobId": 10, "dataCount": -1}]
+
+    job.download_json(test_download_jobs)
+
+    gzip_open.assert_called()
+    copyfileobj.assert_called()
+    verify_downloads.assert_called()
 
 
 @patch.object(ArchiveAFCAPI, "api_job_ids")


### PR DESCRIPTION
Asana ticket: https://app.asana.com/1/15492006741476/task/1213090243017307

This error can be caused by trying to read from incompletely written files. There's two obvious ways this could happen; either reading the file from the AFC endpoint was cut short, or the downloaded JSON gzip file wasn't completely available on disk before it was re-opened to be unzipped (much less likely, but could be due to AWS drive latency, plausibly.) In either case the error is less likely to persist if we simply re-try the download process a few times.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213090243017307