### PR TITLE
Hardening handling for trailing slashes in parquet functions

### DIFF
--- a/src/odin/utils/parquet.py
+++ b/src/odin/utils/parquet.py
@@ -90,6 +90,8 @@ def pq_rows_per_mb(source: Union[str, Sequence[str]], num_rows: Optional[int] = 
     if isinstance(source, str):
         if not source.endswith(".parquet"):
             # assume S3 partition
+            if not source.endswith("/"):
+                source = f"{source}/"
             paths += [obj.path for obj in list_objects(source)]
         else:
             paths.append(source)
@@ -214,6 +216,8 @@ def ds_from_path(source: Union[str, Sequence[str]]) -> pd.UnionDataset:
             paths.append(source)
         # S3 partition path
         elif source.startswith("s3://"):
+            if not source.endswith("/"):
+                source = f"{source}/"
             paths = [o.path for o in list_objects(source, in_filter=".parquet")]
         # local partition path
         else:
@@ -338,6 +342,7 @@ def fast_last_mod_ds_max(partition: str, column: str) -> Any:
 
     :return: column max value
     """
+    partition = partition.rstrip("/") + "/"
     log = ProcessLog("fast_last_mod_ds_max", partition=partition, column=column)
     part_objs = list_objects(partition, in_filter=".parquet")
     if len(part_objs) == 0:


### PR DESCRIPTION
This PR addresses a critical bug that was causing inconsistent update behavior for tables which have names that are prefixes of other existing table names, e.g. `EDW.PATRON_ORDER`, which is a prefix to tables including `EDW.PATRON_ORDER_PAYMENT`.

The crux of this bug is `fast_last_mod_ds_max()`, which "[finds the] max value of column from the file of parquet partition that was most recently modified", and which was being called as `self.fact_snapshot = str(fast_last_mod_ds_max(self.s3_export, "odin_snapshot"))` without checks to ensure that `self.s3_export` included a trailing slash (which it never does). The S3 filesystem works based on common prefixes rather than directory structures, so this resulted in `self.fact_snapshot` being pulled from whichever table matching `EDW.PATRON_ORDER*` that had been updated most recently.

The code here addresses this issue directly in `fast_last_mod_ds_max()` by enforcing that `partition` ends appropriately with a trailing slash (`partition = partition.rstrip("/") + "/"`). It also adds similar logic to two additional parquet functions which unambiguously expect a path with a trailing slash:

`ds_from_path()`:
```
        # S3 partition path
        elif source.startswith("s3://"):
+           if not source.endswith("/"):
+               source = f"{source}/"
```

`pq_rows_per_mb()`:
```
        if not source.endswith(".parquet"):
            # assume S3 partition
+           if not source.endswith("/"):
+               source = f"{source}/"
```

Fortunately, after this fix, the tables involved should be able to recover without further intervention. I will check these against dmap to ensure that the records match. In the event I am still seeing a mismatch, I will trigger a full refresh via deleting the fact tables in a migration.

I will continue auditing this repo for other potential similar issues in other Odin jobs (archive_* and dictionary), but that is out of scope for this PR. I have combed through ods_fact.py and can be reasonably certain that no similar bugs exist in the fact table generation process, as every instance of `self.s3_export` appears to be handled appropriately.
