### PR TITLE
URL env var fix and adding to validation

### DIFF
--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -20,7 +20,7 @@ from odin.utils.locations import DATA_SPRINGBOARD, MASABI_DATA
 # ---------------------------------------------------------------------------
 
 # API base URL
-API_ROOT = os.getenv("MASABI_API_ROOT", "")
+API_ROOT = os.getenv("MASABI_DATA_API_URL", "")
 
 # Basic-auth credentials (validated at startup by run.py)
 _API_USERNAME = os.getenv("MASABI_DATA_API_USERNAME", "")

--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -44,10 +44,13 @@ def start():
             "DATA_SPRINGBOARD",
         ],
         private=[
+            "AFC_ROOT",
             "AFC_API_CLIENT_ID",
             "AFC_API_CLIENT_SECRET",
+            "TABLEAU_SERVER_URL",
             "TABLEAU_PERSONAL_ACCESS_TOKEN_NAME",
             "TABLEAU_PERSONAL_ACCESS_TOKEN_SECRET",
+            "MASABI_DATA_API_URL",
             "MASABI_DATA_API_USERNAME",
             "MASABI_DATA_API_PASSWORD",
         ],


### PR DESCRIPTION
Previous addition to the Masabi pipeline used an incorrect URL variable, which is fixed here.

To prevent this kind of difficulty in the future, URL env variables are also added to the validation check on Odin start.