### PR TITLE
Feat: Add data repository integration step for Masabi data

### DIFF
--- a/src/odin/generate/data_dictionary/duck_db.py
+++ b/src/odin/generate/data_dictionary/duck_db.py
@@ -13,6 +13,7 @@ from odin.utils.locations import CUBIC_QLIK_DATA
 from odin.utils.locations import AFC_DATA
 from odin.utils.locations import AFC_RESTRICTED
 from odin.utils.locations import CUBIC_ODS_REPORTS
+from odin.utils.locations import MASABI_DATA
 from odin.utils.parquet import ds_from_path
 import odin.generate.data_dictionary.cubic_reports_sql as cubic_sql
 
@@ -62,6 +63,13 @@ dataset_views = [
                 f"{DROP_VIEW} CREATE VIEW $schema.$table AS SELECT $columns FROM {READ_PQ} "
                 f"WHERE snapshot=(SELECT max(snapshot) FROM {READ_PQ});"
             )
+        ),
+    ),
+    ViewBuilder(
+        s3_prefix=os.path.join(DATA_SPRINGBOARD, MASABI_DATA),
+        schema="masabi",
+        template=Template(
+            f"{DROP_VIEW} CREATE VIEW $schema.$table AS SELECT $columns FROM {READ_PQ};"
         ),
     ),
 ]


### PR DESCRIPTION
Asana ticket: https://app.asana.com/1/15492006741476/project/1203930661880158/task/1213666250518225?focus=true

Adds the view definition for the `masabi` schema into the duckdb update set, connected to the MASABI_DATA S3 data populated by the earlier Masabi pipeline components.