### PR TITLE
feat: Addressing bug in load_cdc_records, adding test suite

### DIFF
--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -393,50 +393,45 @@ class CubicODSFact(OdinJob):
         # then fetch existing fact rows and apply the updates.
         update_keys = resolved_updates.select(keys)
         if update_keys.height > 0:
-            # Build per-column update values from all U records matching update keys
-            u_records = cdc_df.cast(mod_cast).filter(pl.col("header__change_oper").eq("U"))
-            update_values = update_keys.clone()
-            for col in u_records.columns:
-                if col in keys:
-                    continue
-                col_df = (
-                    u_records.filter(pl.col(col).is_not_null())
-                    .sort(by="header__change_seq", descending=True)
-                    .unique(keys, keep="first")
-                    .select(keys + [col])
-                )
-                if col_df.height == 0:
-                    continue
-                if col in update_values.columns:
-                    update_values = update_values.pipe(pl_pipe_update, col_df, keys)
-                else:
-                    update_values = update_values.join(
-                        col_df, on=keys, how="left", nulls_equal=True, coalesce=True
-                    )
+            # Build per-key sparse update values: for each non-key column, take
+            # the latest non-null value across all U records for that key.
+            # Pre-sorting by seq desc means group_by().agg(drop_nulls().first())
+            # picks the highest-seq non-null value per column per key.
+            u_records = (
+                cdc_df.cast(mod_cast)
+                .filter(pl.col("header__change_oper").eq("U"))
+                .join(update_keys, on=keys, how="semi", nulls_equal=True)
+                .sort(by="header__change_seq", descending=True)
+            )
+            non_key_cols = [c for c in u_records.columns if c not in keys]
+            update_values = u_records.group_by(keys).agg(
+                [pl.col(c).drop_nulls().first() for c in non_key_cols]
+            )
 
-            # Fetch existing fact rows for these keys and apply updates
+            # Fetch existing fact rows for these keys
             existing_rows = ds_batched_join(
                 fact_ds, update_values.cast(orig_cast), keys, self.batch_size
             )
 
             # I→U in same batch: key was inserted and then updated, so no
             # existing fact row exists. Fall back to the I record as the base.
-            if existing_rows.height < update_keys.height:
-                found_keys = existing_rows.select(keys).cast(mod_cast)
-                missing_keys = update_keys.join(found_keys, on=keys, how="anti", nulls_equal=True)
-                if missing_keys.height > 0:
-                    insert_base = (
-                        cdc_df.cast(mod_cast)
-                        .filter(pl.col("header__change_oper").eq("I"))
-                        .sort(by="header__change_seq", descending=True)
-                        .unique(keys, keep="first")
-                        .join(missing_keys, on=keys, how="inner", nulls_equal=True)
-                    )
-                    if insert_base.height > 0:
-                        existing_rows = pl.concat(
-                            [existing_rows.cast(mod_cast), insert_base],
-                            how="diagonal",
-                        ).cast(orig_cast)
+            # Note: resolved_inserts cannot be used here because it only contains
+            # keys whose FINAL operation is I. For I→U keys the final op is U,
+            # so the I record only exists in the raw cdc_df.
+            found_keys = existing_rows.select(keys).cast(mod_cast)
+            missing_keys = update_keys.join(found_keys, on=keys, how="anti", nulls_equal=True)
+            if missing_keys.height > 0:
+                insert_base = (
+                    cdc_df.cast(mod_cast)
+                    .filter(pl.col("header__change_oper").eq("I"))
+                    .sort(by="header__change_seq", descending=True)
+                    .unique(keys, keep="first")
+                    .join(missing_keys, on=keys, how="inner", nulls_equal=True)
+                )
+                if insert_base.height > 0:
+                    existing_rows = pl.concat(
+                        [existing_rows.cast(mod_cast), insert_base], how="diagonal"
+                    ).cast(orig_cast)
 
             if existing_rows.height > 0:
                 if "odin_year" in existing_rows.columns:

--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -324,19 +324,16 @@ class CubicODSFact(OdinJob):
              upload to S3.
         """
         # --- Step 1: Load current fact table state ---
+        logger = ProcessLog("load_cdc_records", table=self.table)
         fact_ds = ds_from_path(s3_folder(self.s3_export))
         initial_row_count = fact_ds.count_rows()
         _, max_fact_seq = ds_metadata_min_max(fact_ds, "header__change_seq")
         _, max_odin_index = ds_metadata_min_max(fact_ds, "odin_index")
-
-        init_log = ProcessLog(
-            "load_cdc_initial_state",
-            table=self.table,
+        logger.add_metadata(
             initial_row_count=initial_row_count,
             max_fact_seq=str(max_fact_seq),
             max_odin_index=str(max_odin_index),
         )
-        init_log.complete()
 
         # --- Step 2: Accumulate CDC records ---
         cdc_filter = (
@@ -365,7 +362,7 @@ class CubicODSFact(OdinJob):
                 break
 
         if not all_cdc_frames:
-            ProcessLog("load_cdc_no_records", table=self.table).complete()
+            logger.complete(cdc_records_found=0)
             return NEXT_RUN_LONG
 
         cdc_df = pl.concat(all_cdc_frames, how="diagonal")
@@ -545,23 +542,20 @@ class CubicODSFact(OdinJob):
                 max_rows=max_load_records,
             ).height
 
-        ProcessLog(
-            "load_cdc_complete",
-            table=self.table,
+        logger.complete(
             cdc_records_processed=cdc_df.height,
             resolved_inserts=resolved_inserts.height,
             resolved_updates=resolved_updates.height,
             resolved_deletes=resolved_deletes.height,
             rows_dropped=rows_dropped,
             rows_inserted=rows_inserted,
-            initial_row_count=initial_row_count,
             final_row_count=final_row_count,
             expected_row_count=expected_row_count,
             row_count_mismatch=row_count_mismatch,
             s3_verify_seq_min=str(verify_min),
             s3_verify_seq_max=str(verify_max),
             ds_available_count=ds_available_count,
-        ).complete()
+        )
 
         if ds_available_count > int(0.9 * max_load_records):
             return NEXT_RUN_IMMEDIATE

--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -74,71 +74,6 @@ def pl_pipe_update(left: pl.DataFrame, right: pl.DataFrame, keys: List[str]) -> 
     )
 
 
-def cdc_to_fact(
-    cdc_df: pl.DataFrame,
-    insert_df: pl.DataFrame,
-    update_df: pl.DataFrame,
-    delete_df: pl.DataFrame,
-    keys: List[str],
-) -> Tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
-    """
-    Convert Qlik CDC records to fact dataframes.
-
-    :param cdc_df: Dataframe of CDC records from qlik history dataset
-    :param insert_df: Dataframe of CDC INSERT records
-    :param update_df: Dataframe of CDC UPDATE records
-    :param delete_df: Dataframe of CDC DELETE records
-    :param keys: ODS Table Keys (for unique operations)
-
-    :return: Tuple[new INSERT df, new UPDATE df, new DELETE df]
-    """
-    insert_df = pl.concat(
-        [insert_df, cdc_df.filter(pl.col("header__change_oper").eq("I"))],
-        how="diagonal",
-    )
-    delete_df = pl.concat(
-        [delete_df, cdc_df.filter(pl.col("header__change_oper").eq("D"))],
-        how="diagonal",
-    )
-
-    mod_cast, orig_cast = polars_decimal_as_string(cdc_df.select(keys))
-    cdc_df = cdc_df.cast(mod_cast)
-
-    # add keys from cdc to update, if not present
-    if update_df.shape[0] == 0:
-        update_df = cdc_df.select(keys).unique()
-    else:
-        update_df = update_df.cast(mod_cast).join(
-            cdc_df.select(keys).unique(),
-            on=keys,
-            how="full",
-            nulls_equal=True,
-            coalesce=True,
-        )
-
-    # perform per-column cdc -> fact update
-    for col in cdc_df.columns:
-        if col in keys:
-            continue
-        _df = (
-            cdc_df.filter(
-                pl.col("header__change_oper").eq("U"),
-                pl.col(col).is_not_null(),
-            )
-            .sort(by="header__change_seq", descending=True)
-            .unique(keys, keep="first")
-            .select(keys + [col])
-        )
-        if _df.shape[0] == 0:
-            continue
-        if col in update_df.columns:
-            update_df = update_df.pipe(pl_pipe_update, _df, keys)
-        else:
-            update_df = update_df.join(_df, on=keys, how="left", nulls_equal=True, coalesce=True)
-
-    return (insert_df, update_df.cast(orig_cast), delete_df)
-
-
 def dfm_from_cdc_records(cdc_df: pl.DataFrame) -> QlikDFM:
     """
     Produce Qlik DFM record from CDC Dataframe.
@@ -361,123 +296,244 @@ class CubicODSFact(OdinJob):
         )
         load_complete_log.complete()
 
+
     def load_cdc_records(self) -> int:
         """
-        Load change records from history files.
+        Load CDC records and apply to fact table.
 
-        Qlik CDC Records consists of 5 potential header__change_seq values:
-        - I (Insert records)
-        - D (Delete records)
-        - U (After Update records)
-        - B (Before Update records)
-        - Null (Initial snapshot load records (same as Insert but from LOAD.. files))
+        Simplified CDC pipeline that resolves each key to a single final operation
+        before touching the fact table. This avoids the interleaving issues of
+        building separate insert/update/delete dataframes simultaneously.
 
-        "B" Records are ignored for this process as they do not contain any relevant information.
+        Order of operations:
+          1. Read the current fact table and its max header__change_seq.
+          2. Pull CDC records (I/U/D) from history with seq > max_fact_seq.
+             Repeat in a loop to accumulate enough work.
+          3. For every key touched by CDC, determine the FINAL operation:
+             sort all CDC records by header__change_seq descending, deduplicate
+             by key keeping the latest. The latest oper wins.
+          4. Build a single "new_rows" dataframe:
+             - For keys whose final op is I: use the I record directly.
+             - For keys whose final op is U: fetch the existing fact row, apply
+               the sparse column updates, produce an updated row.  If no fact
+               row exists (I→U in same batch), use the I record as the base.
+             - For keys whose final op is D: no new row (just drop the old one).
+          5. Collect odin_index values of all fact rows being replaced or deleted
+             (any key in the CDC batch that already exists in fact_ds).
+          6. Write: filter old dataset to exclude touched rows, union with new_rows,
+             upload to S3.
         """
-        # Load fact dataset and get current max sequence
-        s3_objects = list_objects(f"s3://{self.s3_export}/", in_filter=".parquet")
+        # --- Step 1: Load current fact table state ---
         fact_ds = ds_from_path(f"s3://{self.s3_export}/")
-        fact_files = ds_files(fact_ds)
         initial_row_count = fact_ds.count_rows()
         _, max_fact_seq = ds_metadata_min_max(fact_ds, "header__change_seq")
+        _, max_odin_index = ds_metadata_min_max(fact_ds, "odin_index")
 
-        # Log initial fact table state
         init_log = ProcessLog(
             "load_cdc_initial_state",
             table=self.table,
-            s3_file_count=len(s3_objects),
-            fact_ds_file_count=len(fact_files),
             initial_row_count=initial_row_count,
-            max_fact_seq_metadata=str(max_fact_seq),
+            max_fact_seq=str(max_fact_seq),
+            max_odin_index=str(max_odin_index),
         )
         init_log.complete()
 
+        # --- Step 2: Accumulate CDC records ---
         cdc_filter = (
             (pc.field("header__change_oper") == "I")
             | (pc.field("header__change_oper") == "D")
             | (pc.field("header__change_oper") == "U")
         )
-        cdc_df = ds_metadata_limit_k_sorted(
-            ds=self.history_ds,
-            sort_column="header__change_seq",
-            min_sort_value=max_fact_seq,
-            ds_filter=cdc_filter,
-            ds_filter_columns=["header__change_oper"],
-        )
-
-        # Log CDC fetch result
-        cdc_log = ProcessLog(
-            "load_cdc_fetch",
-            table=self.table,
-            cdc_df_height=cdc_df.height,
-            max_fact_seq_used=str(max_fact_seq),
-        )
-        if cdc_df.height == 0:
-            hist_min, hist_max = ds_metadata_min_max(self.history_ds, "header__change_seq")
-            cdc_log.add_metadata(
-                history_min_seq=str(hist_min),
-                history_max_seq=str(hist_max),
+        all_cdc_frames: list[pl.DataFrame] = []
+        current_min_seq = max_fact_seq
+        max_load_records = 10_000
+        for _ in range(11):
+            batch_df = ds_metadata_limit_k_sorted(
+                ds=self.history_ds,
+                sort_column="header__change_seq",
+                min_sort_value=current_min_seq,
+                ds_filter=cdc_filter,
+                ds_filter_columns=["header__change_oper"],
             )
-        else:
-            cdc_log.add_metadata(
-                cdc_seq_min=str(cdc_df.get_column("header__change_seq").min()),
-                cdc_seq_max=str(cdc_df.get_column("header__change_seq").max()),
-            )
-        cdc_log.complete()
+            if batch_df.height == 0:
+                break
+            all_cdc_frames.append(batch_df)
+            current_min_seq = batch_df.get_column("header__change_seq").max()
+            max_load_records = max(max_load_records, batch_df.height)
+            total_cdc = sum(f.height for f in all_cdc_frames)
+            if total_cdc > max_load_records:
+                break
 
-        max_load_records = max(10_000, cdc_df.height)
-
-        if cdc_df.height == 0:
+        if not all_cdc_frames:
+            ProcessLog("load_cdc_no_records", table=self.table).complete()
             return NEXT_RUN_LONG
 
+        cdc_df = pl.concat(all_cdc_frames, how="diagonal")
+        del all_cdc_frames
+
+        # Get table keys from DFM
         dfm = dfm_from_cdc_records(cdc_df)
         keys = [
             col["name"].lower() for col in dfm["dataInfo"]["columns"] if col["primaryKeyPos"] > 0
         ]
 
-        insert_df, update_df, delete_df = cdc_to_fact(
-            cdc_df, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), keys
+        # --- Step 3: Resolve each key to its FINAL operation ---
+        # Sort by seq descending, deduplicate by key keeping the latest record.
+        # The header__change_oper of this record is the "winning" operation.
+        mod_cast, orig_cast = polars_decimal_as_string(cdc_df.select(keys))
+        resolved = (
+            cdc_df.cast(mod_cast)
+            .sort(by="header__change_seq", descending=True)
+            .unique(keys, keep="first")
+        )
+        resolved_deletes = resolved.filter(pl.col("header__change_oper").eq("D"))
+        resolved_inserts = resolved.filter(pl.col("header__change_oper").eq("I"))
+        resolved_updates = resolved.filter(pl.col("header__change_oper").eq("U"))
+
+        # --- Step 4: Build new_rows ---
+
+        # 4a. For updates: build sparse column values from ALL U records for these keys,
+        # then fetch existing fact rows and apply the updates.
+        update_keys = resolved_updates.select(keys)
+        new_update_rows = pl.DataFrame()
+        if update_keys.height > 0:
+            # Build per-column update values from all U records matching update keys
+            u_records = cdc_df.cast(mod_cast).filter(pl.col("header__change_oper").eq("U"))
+            update_values = update_keys.clone()
+            for col in u_records.columns:
+                if col in keys:
+                    continue
+                col_df = (
+                    u_records.filter(pl.col(col).is_not_null())
+                    .sort(by="header__change_seq", descending=True)
+                    .unique(keys, keep="first")
+                    .select(keys + [col])
+                )
+                if col_df.height == 0:
+                    continue
+                if col in update_values.columns:
+                    update_values = update_values.pipe(pl_pipe_update, col_df, keys)
+                else:
+                    update_values = update_values.join(
+                        col_df, on=keys, how="left", nulls_equal=True, coalesce=True
+                    )
+
+            # Fetch existing fact rows for these keys and apply updates
+            existing_rows = ds_batched_join(
+                fact_ds, update_values.cast(orig_cast), keys, self.batch_size
+            )
+
+            # I→U in same batch: key was inserted and then updated, so no
+            # existing fact row exists. Fall back to the I record as the base.
+            if existing_rows.height < update_keys.height:
+                found_keys = existing_rows.select(keys).cast(mod_cast)
+                missing_keys = update_keys.join(
+                    found_keys, on=keys, how="anti", nulls_equal=True
+                )
+                if missing_keys.height > 0:
+                    insert_base = (
+                        cdc_df.cast(mod_cast)
+                        .filter(pl.col("header__change_oper").eq("I"))
+                        .sort(by="header__change_seq", descending=True)
+                        .unique(keys, keep="first")
+                        .join(missing_keys, on=keys, how="inner", nulls_equal=True)
+                    )
+                    if insert_base.height > 0:
+                        existing_rows = pl.concat(
+                            [existing_rows.cast(mod_cast), insert_base],
+                            how="diagonal",
+                        ).cast(orig_cast)
+
+            if existing_rows.height > 0:
+                if "odin_year" in existing_rows.columns:
+                    existing_rows = existing_rows.cast({"odin_year": pl.Int32()})
+                new_update_rows = (
+                    existing_rows.cast(mod_cast)
+                    .pipe(
+                        pl_pipe_update,
+                        update_values.drop(self.history_drop_columns, strict=False),
+                        keys,
+                    )
+                    .cast(orig_cast)
+                )
+
+        # 4b. For inserts: use the I records directly (drop CDC header columns)
+        new_insert_rows = resolved_inserts.cast(orig_cast)
+
+        # Combine new rows and assign odin_index / odin_snapshot
+        new_rows_parts = [df for df in [new_update_rows, new_insert_rows] if df.height > 0]
+        if new_rows_parts:
+            new_rows = pl.concat(new_rows_parts, how="diagonal")
+        else:
+            new_rows = pl.DataFrame()
+
+        if new_rows.height > 0:
+            start_odin_index = max_odin_index + 1
+            new_rows = new_rows.with_columns(
+                pl.arange(
+                    start_odin_index, start_odin_index + new_rows.height, dtype=pl.Int64()
+                ).alias("odin_index"),
+                pl.lit(self.history_snapshot, dtype=pl.String()).alias("odin_snapshot"),
+            ).drop(self.history_drop_columns, strict=False)
+            if "edw_inserted_dtm" in new_rows.columns:
+                new_rows = new_rows.with_columns(
+                    pl.coalesce(pl.col("edw_inserted_dtm").dt.strftime("%Y"), 0)
+                    .cast(pl.Int32())
+                    .alias("odin_year")
+                )
+
+        # --- Step 5: Find odin_index values to drop from fact_ds ---
+        # Any key that appears in CDC (regardless of operation) and exists in the
+        # fact table must have its old row removed. Updates get a replacement row
+        # in new_rows; deletes do not.
+        all_touched_keys = resolved.select(keys).cast(orig_cast)
+        existing_touched = ds_batched_join(fact_ds, all_touched_keys, keys, self.batch_size)
+        drop_indices = existing_touched.get_column("odin_index")
+
+        # --- Step 6: Write merged result to S3 ---
+        sync_filter = ~pc.field("odin_index").isin(drop_indices.to_arrow())
+        part_columns = self.part_columns if self.part_columns else None
+
+        # Write new_rows to temp file
+        insert_path = os.path.join(self.tmpdir, "temp_insert.parquet")
+        if new_rows.height > 0:
+            new_rows.write_parquet(insert_path)
+
+        # Write filtered fact_ds (old rows minus touched keys)
+        sync_paths = pq_dataset_writer(
+            fact_ds.filter(sync_filter),
+            partition_columns=part_columns,
+            export_folder=self.tmpdir,
+            export_file_prefix="temp_sync",
+        )
+        if new_rows.height > 0:
+            sync_paths.append(insert_path)
+
+        # Merge into final parquet files
+        new_paths = pq_dataset_writer(
+            source=ds_from_path(sync_paths),
+            partition_columns=part_columns,
+            export_folder=os.path.join(self.tmpdir, self.s3_export),
+            export_file_prefix="year",
         )
 
-        # many CDC records often impact the same FACT row.
-        # After cdc_to_fact colapses CDC records to FACT format, pull more CDC records until
-        # expected number of FACT records are available for merging
-        loop_iterations = 0
-        for loop_idx in range(10):
-            num_load_records = insert_df.height + delete_df.height + update_df.height
-            if cdc_df.height == 0 or num_load_records > max_load_records:
-                loop_iterations = loop_idx
-                break
-            max_fact_seq = cdc_df.get_column("header__change_seq").max()
-            cdc_df = ds_metadata_limit_k_sorted(
-                ds=self.history_ds,
-                sort_column="header__change_seq",
-                min_sort_value=max_fact_seq,
-                ds_filter=cdc_filter,
-                ds_filter_columns=["header__change_oper"],
-            )
-            insert_df, update_df, delete_df = cdc_to_fact(
-                cdc_df, insert_df, update_df, delete_df, keys
-            )
+        # Upload
+        sigterm_check()
+        for new_path in new_paths:
+            move_path = new_path.replace(f"{self.tmpdir}/", "")
+            upload_file(new_path, move_path)
 
-        # Log CDC processing summary after loop
-        cdc_final_seq = cdc_df.get_column("header__change_seq").max() if cdc_df.height > 0 else None
-        process_log = ProcessLog(
-            "load_cdc_processing",
-            table=self.table,
-            loop_iterations=loop_iterations,
-            insert_df_height=insert_df.height,
-            update_df_height=update_df.height,
-            delete_df_height=delete_df.height,
-            final_cdc_seq_max=str(cdc_final_seq) if cdc_final_seq else None,
-        )
-        process_log.complete()
+        # --- Verify and log ---
+        verify_ds = ds_from_path(f"s3://{self.s3_export}/")
+        verify_min, verify_max = ds_metadata_min_max(verify_ds, "header__change_seq")
+        final_row_count = verify_ds.count_rows()
 
-        # Track counts for row validation (before insert_df is modified by update merge)
-        delete_count = delete_df.height
-        original_insert_count = insert_df.height
+        rows_dropped = drop_indices.n_unique()
+        rows_inserted = new_rows.height
+        expected_row_count = initial_row_count - rows_dropped + rows_inserted
+        row_count_mismatch = final_row_count != expected_row_count
 
-        # Determine if next run should be immediate
+        # Check if more CDC records are available
         ds_available_count = 0
         if cdc_df.height > 0:
             ds_available_count = ds_metadata_limit_k_sorted(
@@ -489,117 +545,23 @@ class CubicODSFact(OdinJob):
                 max_rows=max_load_records,
             ).height
 
-        if insert_df.height > 0:
-            _, max_odin_index = ds_metadata_min_max(fact_ds, "odin_index")
-            start_odin_index = max_odin_index + 1
-            insert_df = insert_df.with_columns(
-                pl.arange(
-                    start_odin_index, start_odin_index + insert_df.height, dtype=pl.Int64()
-                ).alias("odin_index"),
-                pl.lit(self.history_snapshot, dtype=pl.String()).alias("odin_snapshot"),
-            ).drop(self.history_drop_columns, strict=False)
-            if "edw_inserted_dtm" in insert_df.columns:
-                insert_df = insert_df.with_columns(
-                    pl.coalesce(pl.col("edw_inserted_dtm").dt.strftime("%Y"), 0)
-                    .cast(pl.Int32())
-                    .alias("odin_year")
-                )
-
-        drop_indices = pl.Series("odin_index", [], pl.Int64())
-        if update_df.height > 0:
-            update_df = update_df.drop(self.history_drop_columns, strict=False)
-            mod_cast, orig_cast = polars_decimal_as_string(update_df.select(keys))
-            s3_update_df = ds_batched_join(fact_ds, update_df, keys, self.batch_size)
-            if "odin_year" in s3_update_df.columns:
-                s3_update_df = s3_update_df.cast({"odin_year": pl.Int32()})
-            insert_df = pl.concat([s3_update_df, insert_df], how="diagonal")
-            insert_df = (
-                insert_df.cast(mod_cast)
-                .pipe(pl_pipe_update, update_df.cast(mod_cast), keys)
-                .cast(orig_cast)
-            )
-            del update_df
-            del s3_update_df
-            drop_indices = pl.concat([drop_indices, insert_df.get_column("odin_index")])
-
-        if delete_df.height > 0:
-            s3_delete_df = ds_batched_join(fact_ds, delete_df, keys, self.batch_size)
-            drop_indices = pl.concat([drop_indices, s3_delete_df.get_column("odin_index")])
-            del s3_delete_df
-
-        sync_filter = ~pc.field("odin_index").isin(drop_indices.to_arrow())
-        if self.part_columns:
-            part_columns = self.part_columns
-        else:
-            part_columns = None
-        insert_path = os.path.join(self.tmpdir, "temp_insert.parquet")
-        insert_df.write_parquet(insert_path)
-        # TODO: This process creates an entire new copy of all `fact_ds` parquet files with all
-        # UPDATE and DELETE Records removed. This could be done much more efficiently by only
-        # re-writing parquet files that contain `odin_index` records being touched.
-        # This would probably require a re-writing of the `ds_batch_join` function to also return
-        # a list of parquet files with matching JOIN records.
-        # If a single parquet dataset grows larger than the disk space available in the ECS, this
-        # process will also likely begin to fail.
-        sync_paths = pq_dataset_writer(
-            fact_ds.filter(sync_filter),
-            partition_columns=part_columns,
-            export_folder=self.tmpdir,
-            export_file_prefix="temp_sync",
-        )
-        sync_paths.append(insert_path)
-
-        # Create new merged parquet file(s)
-        new_paths = pq_dataset_writer(
-            source=ds_from_path(sync_paths),
-            partition_columns=part_columns,
-            export_folder=os.path.join(self.tmpdir, self.s3_export),
-            export_file_prefix="year",
-        )
-
-        # Get final seq max before upload for logging
-        final_insert_seq_max = (
-            insert_df.get_column("header__change_seq").max()
-            if "header__change_seq" in insert_df.columns
-            else None
-        )
-
-        # Check for sigterm before upload (can't be un-done)
-        sigterm_check()
-        for new_path in new_paths:
-            move_path = new_path.replace(f"{self.tmpdir}/", "")
-            upload_file(new_path, move_path)
-
-        # Verify uploads and log final state
-        verify_ds = ds_from_path(f"s3://{self.s3_export}/")
-        verify_min, verify_max = ds_metadata_min_max(verify_ds, "header__change_seq")
-        verify_objects = list_objects(f"s3://{self.s3_export}/", in_filter=".parquet")
-        final_row_count = verify_ds.count_rows()
-
-        # Row count validation: original inserts add rows, deletes remove rows, updates are net-zero
-        # Note: insert_df.height includes updated rows (which are re-added after being dropped),
-        # so we use original_insert_count captured before update merge
-        expected_row_count = initial_row_count + original_insert_count - delete_count
-        row_count_mismatch = final_row_count != expected_row_count
-
-        upload_log = ProcessLog(
-            "load_cdc_upload_complete",
+        ProcessLog(
+            "load_cdc_complete",
             table=self.table,
-            files_uploaded=len(new_paths),
-            original_insert_count=original_insert_count,
-            final_insert_df_height=insert_df.height,
-            final_insert_seq_max=str(final_insert_seq_max) if final_insert_seq_max else None,
-            s3_verify_seq_min=str(verify_min),
-            s3_verify_seq_max=str(verify_max),
-            s3_verify_file_count=len(verify_objects),
+            cdc_records_processed=cdc_df.height,
+            resolved_inserts=resolved_inserts.height,
+            resolved_updates=resolved_updates.height,
+            resolved_deletes=resolved_deletes.height,
+            rows_dropped=rows_dropped,
+            rows_inserted=rows_inserted,
             initial_row_count=initial_row_count,
             final_row_count=final_row_count,
             expected_row_count=expected_row_count,
-            delete_count=delete_count,
             row_count_mismatch=row_count_mismatch,
+            s3_verify_seq_min=str(verify_min),
+            s3_verify_seq_max=str(verify_max),
             ds_available_count=ds_available_count,
-        )
-        upload_log.complete()
+        ).complete()
 
         if ds_available_count > int(0.9 * max_load_records):
             return NEXT_RUN_IMMEDIATE

--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -32,6 +32,7 @@ from odin.utils.aws.s3 import list_objects
 from odin.utils.aws.s3 import delete_objects
 from odin.utils.aws.s3 import download_object
 from odin.utils.aws.s3 import upload_file
+from odin.utils.aws.s3 import s3_folder
 from odin.ingestion.qlik.dfm import dfm_from_s3
 from odin.ingestion.qlik.dfm import QlikDFM
 from odin.ingestion.qlik.tables import CUBIC_ODS_TABLES
@@ -39,6 +40,7 @@ from odin.ingestion.qlik.tables import CUBIC_ODS_TABLES
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
 NEXT_RUN_IMMEDIATE = 60 * 5  # 5 minutes
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
+MAX_LOAD_RECORDS = 10_000
 
 
 class NoQlikHistoryError(Exception):
@@ -191,7 +193,7 @@ class CubicODSFact(OdinJob):
     def load_new_snapshot(self) -> None:
         """Load new snapshot from history tables"""
         # Log what will be deleted before the destructive operation
-        existing_objects = list_objects(f"{self.s3_export}/", in_filter=".parquet")
+        existing_objects = list_objects(s3_folder(self.s3_export), in_filter=".parquet")
         existing_paths = [o.path for o in existing_objects]
 
         # Get row count of existing data before deletion
@@ -200,7 +202,7 @@ class CubicODSFact(OdinJob):
         existing_seq_max = None
         if existing_paths:
             try:
-                existing_ds = ds_from_path(f"s3://{self.s3_export}/")
+                existing_ds = ds_from_path(s3_folder(self.s3_export))
                 existing_row_count = existing_ds.count_rows()
                 existing_seq_min, existing_seq_max = ds_metadata_min_max(
                     existing_ds, "header__change_seq"
@@ -279,9 +281,9 @@ class CubicODSFact(OdinJob):
         self.reset_tmpdir()
 
         # Log completion of new snapshot load
-        verify_ds = ds_from_path(f"s3://{self.s3_export}/")
+        verify_ds = ds_from_path(s3_folder(self.s3_export))
         verify_row_count = verify_ds.count_rows()
-        verify_objects = list_objects(f"{self.s3_export}/", in_filter=".parquet")
+        verify_objects = list_objects(s3_folder(self.s3_export), in_filter=".parquet")
         verify_seq_min, verify_seq_max = ds_metadata_min_max(verify_ds, "header__change_seq")
         load_complete_log = ProcessLog(
             "load_new_snapshot_complete",
@@ -322,7 +324,7 @@ class CubicODSFact(OdinJob):
              upload to S3.
         """
         # --- Step 1: Load current fact table state ---
-        fact_ds = ds_from_path(f"s3://{self.s3_export}/")
+        fact_ds = ds_from_path(s3_folder(self.s3_export))
         initial_row_count = fact_ds.count_rows()
         _, max_fact_seq = ds_metadata_min_max(fact_ds, "header__change_seq")
         _, max_odin_index = ds_metadata_min_max(fact_ds, "odin_index")
@@ -344,7 +346,7 @@ class CubicODSFact(OdinJob):
         )
         all_cdc_frames: list[pl.DataFrame] = []
         current_min_seq = max_fact_seq
-        max_load_records = 10_000
+        max_load_records = MAX_LOAD_RECORDS
         for _ in range(11):
             batch_df = ds_metadata_limit_k_sorted(
                 ds=self.history_ds,
@@ -393,7 +395,6 @@ class CubicODSFact(OdinJob):
         # 4a. For updates: build sparse column values from ALL U records for these keys,
         # then fetch existing fact rows and apply the updates.
         update_keys = resolved_updates.select(keys)
-        new_update_rows = pl.DataFrame()
         if update_keys.height > 0:
             # Build per-column update values from all U records matching update keys
             u_records = cdc_df.cast(mod_cast).filter(pl.col("header__change_oper").eq("U"))
@@ -443,21 +444,24 @@ class CubicODSFact(OdinJob):
             if existing_rows.height > 0:
                 if "odin_year" in existing_rows.columns:
                     existing_rows = existing_rows.cast({"odin_year": pl.Int32()})
-                new_update_rows = (
-                    existing_rows.cast(mod_cast)
-                    .pipe(
-                        pl_pipe_update,
-                        update_values.drop(self.history_drop_columns, strict=False),
-                        keys,
-                    )
-                    .cast(orig_cast)
+            new_update_rows = (
+                existing_rows.cast(mod_cast)
+                .pipe(
+                    pl_pipe_update,
+                    update_values.drop(self.history_drop_columns, strict=False),
+                    keys,
                 )
+                .cast(orig_cast)
+            )
 
         # 4b. For inserts: use the I records directly (drop CDC header columns)
         new_insert_rows = resolved_inserts.cast(orig_cast)
 
         # Combine new rows and assign odin_index / odin_snapshot
-        new_rows_parts = [df for df in [new_update_rows, new_insert_rows] if df.height > 0]
+        new_rows_parts = [new_insert_rows]
+        if update_keys.height > 0:
+            new_rows_parts.append(new_update_rows)
+        new_rows_parts = [df for df in new_rows_parts if df.height > 0]
         if new_rows_parts:
             new_rows = pl.concat(new_rows_parts, how="diagonal")
         else:
@@ -520,7 +524,7 @@ class CubicODSFact(OdinJob):
             upload_file(new_path, move_path)
 
         # --- Verify and log ---
-        verify_ds = ds_from_path(f"s3://{self.s3_export}/")
+        verify_ds = ds_from_path(s3_folder(self.s3_export))
         verify_min, verify_max = ds_metadata_min_max(verify_ds, "header__change_seq")
         final_row_count = verify_ds.count_rows()
 

--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -295,7 +295,6 @@ class CubicODSFact(OdinJob):
         )
         load_complete_log.complete()
 
-
     def load_cdc_records(self) -> int:
         """
         Load CDC records and apply to fact table.
@@ -426,9 +425,7 @@ class CubicODSFact(OdinJob):
             # existing fact row exists. Fall back to the I record as the base.
             if existing_rows.height < update_keys.height:
                 found_keys = existing_rows.select(keys).cast(mod_cast)
-                missing_keys = update_keys.join(
-                    found_keys, on=keys, how="anti", nulls_equal=True
-                )
+                missing_keys = update_keys.join(found_keys, on=keys, how="anti", nulls_equal=True)
                 if missing_keys.height > 0:
                     insert_base = (
                         cdc_df.cast(mod_cast)

--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -21,7 +21,6 @@ from odin.utils.locations import DATA_ARCHIVE
 from odin.utils.locations import CUBIC_QLIK_PROCESSED
 from odin.utils.parquet import fast_last_mod_ds_max
 from odin.utils.parquet import ds_metadata_min_max
-from odin.utils.parquet import ds_files
 from odin.utils.parquet import ds_from_path
 from odin.utils.parquet import ds_unique_values
 from odin.utils.parquet import pq_dataset_writer

--- a/tests/generate/cubic/ods_fact_test.py
+++ b/tests/generate/cubic/ods_fact_test.py
@@ -1,0 +1,720 @@
+"""
+Tests for CubicODSFact CDC handling logic.
+
+Two-tier structure:
+
+  Tier 1 — cdc_to_fact() unit tests
+    Pure DataFrame logic; no I/O, no mocking.  Fast and precise.
+    These are the primary spec for CDC operation semantics and directly
+    pin the Bug 1 regression (pure-delete batches being no-op'd).
+
+  Tier 2 — load_cdc_records() integration tests
+    Local parquet on disk; S3 boundary functions patched to local equivalents.
+    Validates the full apply-CDC-to-fact pipeline end-to-end.
+
+Assumptions documented by the test suite (per Qlik CDC spec §2.4.2):
+  - A NULL value in a "U" record means "no change to this column", NOT
+    "set this column to NULL".  This assumption is implicit in the code's
+    null-skipping filter and is pinned by test_cdc_to_fact_null_update_not_applied.
+"""
+
+import datetime
+import os
+import shutil
+from unittest.mock import patch
+
+import polars as pl
+import pytest
+
+from odin.generate.cubic.ods_fact import (
+    NEXT_RUN_DEFAULT,
+    NEXT_RUN_LONG,
+    CubicODSFact,
+    cdc_to_fact,
+)
+from odin.utils.aws.s3 import S3Object
+from odin.utils.parquet import ds_from_path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+KEYS = ["txn_id"]
+TEST_SNAPSHOT = "20250101T000000Z"
+
+# Relative path (no leading slash) so f"s3://{s3_export}/" is valid.
+S3_EXPORT_PREFIX = "test-bucket/odin/data/cubic/ods/EDW.TEST_TABLE"
+
+
+# ---------------------------------------------------------------------------
+# Schema / DataFrame helpers
+# ---------------------------------------------------------------------------
+
+CDC_SCHEMA = {
+    "txn_id": pl.Int64,
+    "amount": pl.Int64,
+    "status": pl.Utf8,
+    "header__change_seq": pl.Utf8,
+    "header__change_oper": pl.Utf8,
+    "header__from_csv": pl.Utf8,
+    "header__year": pl.Int32,
+    "header__month": pl.Int32,
+    "header__timestamp": pl.Utf8,
+    "snapshot": pl.Utf8,
+}
+
+# Columns retained in the fact table after snapshot load / CDC apply.
+# Mirrors history_drop_columns removal from the full CDC schema.
+FACT_SCHEMA = {
+    "txn_id": pl.Int64,
+    "amount": pl.Int64,
+    "status": pl.Utf8,
+    "header__change_seq": pl.Utf8,
+    "odin_index": pl.Int64,
+    "odin_snapshot": pl.Utf8,
+}
+
+
+def make_cdc_df(rows: list[dict]) -> pl.DataFrame:
+    """Build a CDC DataFrame with the full history parquet schema."""
+    defaults: dict = {
+        "txn_id": None,
+        "amount": None,
+        "status": None,
+        "header__change_seq": None,
+        "header__change_oper": None,
+        "header__from_csv": "s3://archive/processed/test.csv",
+        "header__year": 2025,
+        "header__month": 1,
+        "header__timestamp": None,
+        "snapshot": TEST_SNAPSHOT,
+    }
+    return pl.DataFrame([{**defaults, **r} for r in rows], schema=CDC_SCHEMA)
+
+
+def make_fact_df(rows: list[dict]) -> pl.DataFrame:
+    """Build a fact DataFrame with the post-snapshot-load schema."""
+    defaults: dict = {
+        "txn_id": None,
+        "amount": None,
+        "status": None,
+        "header__change_seq": None,
+        "odin_index": None,
+        "odin_snapshot": TEST_SNAPSHOT,
+    }
+    return pl.DataFrame([{**defaults, **r} for r in rows], schema=FACT_SCHEMA)
+
+
+def mock_dfm_for_keys(keys: list[str]) -> dict:
+    """Minimal DFM dict identifying the given columns as primary keys."""
+    data_cols = ["txn_id", "amount", "status"]
+    return {
+        "dataInfo": {
+            "columns": [
+                {
+                    "name": col,
+                    "primaryKeyPos": (keys.index(col) + 1) if col in keys else 0,
+                }
+                for col in data_cols
+            ]
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# S3 mock helpers (Tier 2)
+# ---------------------------------------------------------------------------
+
+
+def make_s3_mocks(tmp_path):
+    """
+    Return (mock_list_objects, mock_ds_from_path, mock_upload_file) that
+    redirect s3:// paths to the local tmp_path directory tree.
+    """
+
+    def mock_list_objects(partition, in_filter=None, **kwargs):
+        local = partition.replace("s3://", str(tmp_path) + "/")
+        result = []
+        if os.path.exists(local):
+            for root, _, files in os.walk(local):
+                for fname in files:
+                    if in_filter is None or fname.endswith(in_filter.lstrip(".")):
+                        result.append(
+                            S3Object(
+                                path=os.path.join(root, fname),
+                                last_modified=datetime.datetime(2025, 1, 1),
+                                size_bytes=0,
+                            )
+                        )
+        return result
+
+    def mock_ds_from_path(source):
+        if isinstance(source, str) and source.startswith("s3://"):
+            local = source.replace("s3://", str(tmp_path) + "/")
+            return ds_from_path(local)
+        return ds_from_path(source)
+
+    def mock_upload_file(src, dst, **kwargs):
+        full_dst = str(tmp_path / dst)
+        os.makedirs(os.path.dirname(full_dst), exist_ok=True)
+        shutil.copy2(src, full_dst)
+
+    return mock_list_objects, mock_ds_from_path, mock_upload_file
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 fixture and runner
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cdc_integration(tmp_path):
+    """
+    Yield (job, write_fact, write_history, read_fact).
+
+      write_fact(df)     writes df as the live fact parquet.
+      write_history(df)  writes df as history and wires job.history_ds.
+      read_fact()        reads the current live fact parquet as polars DataFrame.
+    """
+    fact_dir = tmp_path / S3_EXPORT_PREFIX
+    fact_dir.mkdir(parents=True)
+
+    history_dir = tmp_path / "history"
+    history_dir.mkdir(parents=True)
+
+    job = CubicODSFact("EDW.TEST_TABLE")
+    job.reset_tmpdir()
+    job.s3_export = S3_EXPORT_PREFIX
+    job.history_snapshot = TEST_SNAPSHOT
+    job.part_columns = []
+    job.batch_size = 1000
+
+    def write_fact(df: pl.DataFrame) -> None:
+        df.write_parquet(str(fact_dir / "year_001.parquet"))
+
+    def write_history(df: pl.DataFrame) -> None:
+        # Write flat (no snapshot= partition directory) to avoid the polars
+        # large_string vs pyarrow hive-partition string type conflict.
+        df.write_parquet(str(history_dir / "history.parquet"))
+        job.history_ds = ds_from_path(str(history_dir / "history.parquet"))
+
+    def read_fact() -> pl.DataFrame:
+        files = list(fact_dir.glob("*.parquet"))
+        assert files, "No fact parquet files found after load_cdc_records"
+        return pl.read_parquet(files).select(list(FACT_SCHEMA.keys()))
+
+    yield job, write_fact, write_history, read_fact
+
+
+def run_load_cdc(job, tmp_path) -> int:
+    """Run load_cdc_records with S3 functions redirected to tmp_path."""
+    mock_list, mock_ds, mock_upload = make_s3_mocks(tmp_path)
+    with (
+        patch("odin.generate.cubic.ods_fact.list_objects", mock_list),
+        patch("odin.generate.cubic.ods_fact.ds_from_path", mock_ds),
+        patch("odin.generate.cubic.ods_fact.upload_file", mock_upload),
+        patch("odin.generate.cubic.ods_fact.sigterm_check"),
+        patch(
+            "odin.generate.cubic.ods_fact.dfm_from_cdc_records",
+            return_value=mock_dfm_for_keys(KEYS),
+        ),
+    ):
+        return job.load_cdc_records()
+
+
+# ===========================================================================
+# TIER 1 — cdc_to_fact() unit tests
+# ===========================================================================
+
+
+def test_cdc_to_fact_pure_inserts():
+    """I records land in insert_df; update_df and delete_df are empty."""
+    cdc = make_cdc_df(
+        [
+            {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "header__change_oper": "I"},
+            {"txn_id": 2, "amount": 200, "header__change_seq": "00002", "header__change_oper": "I"},
+        ]
+    )
+    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
+
+    assert ins.height == 2
+    assert set(ins["txn_id"].to_list()) == {1, 2}
+    assert upd.height == 0
+    assert dlt.height == 0
+
+
+def test_cdc_to_fact_pure_deletes():
+    """
+    D records land in delete_df; update_df must be EMPTY.
+
+    This is the direct regression test for Bug 1: before the fix, update_df
+    was seeded with all CDC keys regardless of operation, causing delete-only
+    batches to be silently no-op'd when applied to the fact table.
+    """
+    cdc = make_cdc_df(
+        [
+            {"txn_id": 1, "header__change_seq": "00001", "header__change_oper": "D"},
+            {"txn_id": 2, "header__change_seq": "00002", "header__change_oper": "D"},
+            {"txn_id": 3, "header__change_seq": "00003", "header__change_oper": "D"},
+        ]
+    )
+    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
+
+    assert ins.height == 0
+    assert upd.height == 0, (
+        f"update_df should be empty for pure-delete batch but has {upd.height} rows. "
+        "This indicates the Bug 1 fix is not applied: delete keys must not seed update_df."
+    )
+    assert dlt.height == 3
+    assert set(dlt["txn_id"].to_list()) == {1, 2, 3}
+
+
+def test_cdc_to_fact_pure_updates():
+    """U records build update_df with correct key + column values; others empty."""
+    cdc = make_cdc_df(
+        [
+            {
+                "txn_id": 1,
+                "amount": 999,
+                "status": "active",
+                "header__change_seq": "00001",
+                "header__change_oper": "U",
+            },
+        ]
+    )
+    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
+
+    assert ins.height == 0
+    assert dlt.height == 0
+    assert upd.height == 1
+    assert upd["txn_id"][0] == 1
+    assert upd["amount"][0] == 999
+    assert upd["status"][0] == "active"
+
+
+def test_cdc_to_fact_before_images_ignored():
+    """B records are fully ignored; all output DataFrames are empty."""
+    cdc = make_cdc_df(
+        [
+            {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "header__change_oper": "B"},
+            {"txn_id": 2, "amount": 200, "header__change_seq": "00002", "header__change_oper": "B"},
+        ]
+    )
+    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
+
+    assert ins.height == 0
+    assert upd.height == 0
+    assert dlt.height == 0
+
+
+def test_cdc_to_fact_update_latest_seq_wins():
+    """
+    When two U records target the same key, the one with the higher
+    header__change_seq wins per column (spec §2.4.3).
+    """
+    cdc = make_cdc_df(
+        [
+            {
+                "txn_id": 1,
+                "amount": 111,
+                "status": "old",
+                "header__change_seq": "00001",
+                "header__change_oper": "U",
+            },
+            {
+                "txn_id": 1,
+                "amount": 999,
+                "status": "new",
+                "header__change_seq": "00002",
+                "header__change_oper": "U",
+            },
+        ]
+    )
+    _, upd, _ = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
+
+    row = upd.filter(pl.col("txn_id") == 1)
+    assert row.height == 1
+    assert row["amount"][0] == 999
+    assert row["status"][0] == "new"
+
+
+def test_cdc_to_fact_null_update_not_applied():
+    """
+    A NULL value in a U record is treated as 'no change', not 'set to NULL'.
+
+    This pins the implicit assumption in the code (spec §2.4.2 note): the
+    pipeline lacks a change_mask and assumes the source never uses NULL to
+    mean 'set-to-NULL'.  If that assumption breaks, this test will need
+    revisiting alongside the apply logic.
+    """
+    cdc = make_cdc_df(
+        [
+            # amount is null — should not overwrite; status has a new value.
+            {
+                "txn_id": 1,
+                "amount": None,
+                "status": "changed",
+                "header__change_seq": "00001",
+                "header__change_oper": "U",
+            },
+        ]
+    )
+    _, upd, _ = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
+
+    assert upd.height == 1
+    assert upd["txn_id"][0] == 1
+    # amount column should not appear in update_df (null value was skipped)
+    assert "amount" not in upd.columns or upd["amount"][0] is None
+    assert upd["status"][0] == "changed"
+
+
+def test_cdc_to_fact_mixed_operations():
+    """I / U / D / B records in one batch each route to the correct DataFrame."""
+    cdc = make_cdc_df(
+        [
+            {
+                "txn_id": 10,
+                "amount": 100,
+                "header__change_seq": "00001",
+                "header__change_oper": "I",
+            },
+            {
+                "txn_id": 20,
+                "amount": 200,
+                "header__change_seq": "00002",
+                "header__change_oper": "U",
+            },
+            {"txn_id": 30, "header__change_seq": "00003", "header__change_oper": "D"},
+            {
+                "txn_id": 40,
+                "amount": 400,
+                "header__change_seq": "00004",
+                "header__change_oper": "B",
+            },
+        ]
+    )
+    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
+
+    assert set(ins["txn_id"].to_list()) == {10}
+    assert set(upd["txn_id"].to_list()) == {20}
+    assert set(dlt["txn_id"].to_list()) == {30}
+    # B record (txn_id=40) must not appear anywhere
+    for df in (ins, upd, dlt):
+        if df.height > 0:
+            assert 40 not in df["txn_id"].to_list()
+
+
+def test_cdc_to_fact_delete_then_insert_same_key():
+    """
+    A D followed by an I for the same key lands in delete_df AND insert_df.
+    update_df must not contain the key (no U records).
+    """
+    cdc = make_cdc_df(
+        [
+            {"txn_id": 1, "header__change_seq": "00001", "header__change_oper": "D"},
+            {"txn_id": 1, "amount": 999, "header__change_seq": "00002", "header__change_oper": "I"},
+        ]
+    )
+    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
+
+    assert 1 in ins["txn_id"].to_list()
+    assert 1 in dlt["txn_id"].to_list()
+    assert upd.height == 0
+
+
+def test_cdc_to_fact_accumulation_across_batches():
+    """
+    Calling cdc_to_fact multiple times (simulating the fetch loop) accumulates
+    results correctly without double-counting.
+    """
+    batch1 = make_cdc_df(
+        [
+            {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "header__change_oper": "I"},
+            {"txn_id": 2, "amount": 200, "header__change_seq": "00002", "header__change_oper": "U"},
+        ]
+    )
+    batch2 = make_cdc_df(
+        [
+            {"txn_id": 3, "header__change_seq": "00003", "header__change_oper": "D"},
+            {"txn_id": 4, "amount": 400, "header__change_seq": "00004", "header__change_oper": "I"},
+        ]
+    )
+
+    ins, upd, dlt = cdc_to_fact(batch1, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
+    ins, upd, dlt = cdc_to_fact(batch2, ins, upd, dlt, KEYS)
+
+    assert set(ins["txn_id"].to_list()) == {1, 4}
+    # update_df accumulates keys from U records only
+    assert set(upd["txn_id"].to_list()) == {2}
+    assert set(dlt["txn_id"].to_list()) == {3}
+
+
+def test_cdc_to_fact_accumulation_deletes_do_not_pollute_updates():
+    """
+    Across multiple batches, D records in a subsequent batch must not add
+    keys to update_df (the specific multi-batch form of Bug 1).
+    """
+    batch1 = make_cdc_df(
+        [
+            {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "header__change_oper": "U"},
+        ]
+    )
+    batch2 = make_cdc_df(
+        [
+            {"txn_id": 2, "header__change_seq": "00002", "header__change_oper": "D"},
+            {"txn_id": 3, "header__change_seq": "00003", "header__change_oper": "D"},
+        ]
+    )
+
+    ins, upd, dlt = cdc_to_fact(batch1, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
+    ins, upd, dlt = cdc_to_fact(batch2, ins, upd, dlt, KEYS)
+
+    # update_df should only contain txn_id=1 (from the U in batch 1)
+    assert set(upd["txn_id"].to_list()) == {1}, (
+        f"update_df contains unexpected keys {upd['txn_id'].to_list()}. "
+        "Delete keys from batch2 must not be merged into update_df."
+    )
+    assert set(dlt["txn_id"].to_list()) == {2, 3}
+
+
+# ===========================================================================
+# TIER 2 — load_cdc_records() integration tests
+# ===========================================================================
+
+
+def test_load_cdc_no_new_records(cdc_integration, tmp_path):
+    """
+    When no CDC records exist beyond the current watermark, returns NEXT_RUN_LONG
+    and the fact table is unchanged.
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {"txn_id": 1, "amount": 100, "header__change_seq": "00010", "odin_index": 0},
+            ]
+        )
+    )
+    # History contains only records at or below the current watermark.
+    write_history(
+        make_cdc_df(
+            [
+                {
+                    "txn_id": 99,
+                    "amount": 0,
+                    "header__change_seq": "00010",
+                    "header__change_oper": "I",
+                },
+            ]
+        )
+    )
+
+    result = run_load_cdc(job, tmp_path)
+
+    assert result == NEXT_RUN_LONG
+    fact = read_fact()
+    assert fact.height == 1
+    assert fact["txn_id"][0] == 1
+
+
+def test_load_cdc_pure_inserts(cdc_integration, tmp_path):
+    """I records increase fact row count; new rows get sequential odin_index."""
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "odin_index": 0},
+                {"txn_id": 2, "amount": 200, "header__change_seq": "00002", "odin_index": 1},
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {
+                    "txn_id": 3,
+                    "amount": 300,
+                    "header__change_seq": "00010",
+                    "header__change_oper": "I",
+                },
+                {
+                    "txn_id": 4,
+                    "amount": 400,
+                    "header__change_seq": "00011",
+                    "header__change_oper": "I",
+                },
+            ]
+        )
+    )
+
+    result = run_load_cdc(job, tmp_path)
+
+    assert result == NEXT_RUN_DEFAULT
+    fact = read_fact()
+    assert fact.height == 4
+    assert set(fact["txn_id"].to_list()) == {1, 2, 3, 4}
+    new_rows = fact.filter(pl.col("txn_id").is_in([3, 4]))
+    assert (new_rows["odin_index"] >= 2).all()
+
+
+def test_load_cdc_pure_deletes(cdc_integration, tmp_path):
+    """
+    D records reduce the fact row count; deleted keys must not reappear.
+
+    This is the end-to-end regression test for Bug 1.  Before the fix,
+    load_cdc_records no-op'd pure-delete batches because update_df was
+    seeded with delete keys, causing the deleted rows to be fetched and
+    re-inserted immediately after being dropped.
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {
+                    "txn_id": i,
+                    "amount": i * 100,
+                    "header__change_seq": f"0000{i}",
+                    "odin_index": i - 1,
+                }
+                for i in range(1, 6)  # txn_id 1–5
+            ]
+        )
+    )
+    # Delete txn_id 1, 2, 3.
+    write_history(
+        make_cdc_df(
+            [
+                {"txn_id": 1, "header__change_seq": "00010", "header__change_oper": "D"},
+                {"txn_id": 2, "header__change_seq": "00011", "header__change_oper": "D"},
+                {"txn_id": 3, "header__change_seq": "00012", "header__change_oper": "D"},
+            ]
+        )
+    )
+
+    run_load_cdc(job, tmp_path)
+
+    fact = read_fact()
+    assert fact.height == 2, (
+        f"Expected 2 rows after 3 deletes from 5, got {fact.height}. "
+        "If 5 rows remain, the Bug 1 fix is not applied."
+    )
+    remaining = set(fact["txn_id"].to_list())
+    assert remaining == {4, 5}
+    assert not remaining.intersection({1, 2, 3}), "Deleted rows reappeared in fact table."
+
+
+def test_load_cdc_pure_updates(cdc_integration, tmp_path):
+    """U records change column values; row count and odin_index are unchanged."""
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 100,
+                    "status": "old",
+                    "header__change_seq": "00001",
+                    "odin_index": 0,
+                },
+                {
+                    "txn_id": 2,
+                    "amount": 200,
+                    "status": "old",
+                    "header__change_seq": "00002",
+                    "odin_index": 1,
+                },
+                {
+                    "txn_id": 3,
+                    "amount": 300,
+                    "status": "old",
+                    "header__change_seq": "00003",
+                    "odin_index": 2,
+                },
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 999,
+                    "status": "new",
+                    "header__change_seq": "00010",
+                    "header__change_oper": "U",
+                },
+                {
+                    "txn_id": 2,
+                    "amount": 888,
+                    "status": "new",
+                    "header__change_seq": "00011",
+                    "header__change_oper": "U",
+                },
+            ]
+        )
+    )
+
+    result = run_load_cdc(job, tmp_path)
+
+    assert result == NEXT_RUN_DEFAULT
+    fact = read_fact()
+    assert fact.height == 3
+
+    row1 = fact.filter(pl.col("txn_id") == 1)
+    row2 = fact.filter(pl.col("txn_id") == 2)
+    row3 = fact.filter(pl.col("txn_id") == 3)
+
+    assert row1["amount"][0] == 999
+    assert row1["status"][0] == "new"
+    assert row2["amount"][0] == 888
+    assert row3["amount"][0] == 300  # unchanged
+    assert row3["status"][0] == "old"  # unchanged
+
+
+def test_load_cdc_mixed_operations(cdc_integration, tmp_path):
+    """
+    A mixed I/U/D batch produces the correct net row count and values.
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "odin_index": 0},
+                {"txn_id": 2, "amount": 200, "header__change_seq": "00002", "odin_index": 1},
+                {"txn_id": 3, "amount": 300, "header__change_seq": "00003", "odin_index": 2},
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {
+                    "txn_id": 2,
+                    "amount": 999,
+                    "header__change_seq": "00010",
+                    "header__change_oper": "U",
+                },
+                {"txn_id": 3, "header__change_seq": "00011", "header__change_oper": "D"},
+                {
+                    "txn_id": 4,
+                    "amount": 400,
+                    "header__change_seq": "00012",
+                    "header__change_oper": "I",
+                },
+            ]
+        )
+    )
+
+    run_load_cdc(job, tmp_path)
+
+    fact = read_fact()
+    # Started with 3; +1 insert, -1 delete, 0 net from update → 3 rows
+    assert fact.height == 3
+    assert set(fact["txn_id"].to_list()) == {1, 2, 4}
+    assert fact.filter(pl.col("txn_id") == 2)["amount"][0] == 999
+    assert fact.filter(pl.col("txn_id") == 1)["amount"][0] == 100  # unchanged

--- a/tests/generate/cubic/ods_fact_test.py
+++ b/tests/generate/cubic/ods_fact_test.py
@@ -1,21 +1,21 @@
 """
 Tests for CubicODSFact CDC handling logic.
 
-Two-tier structure:
+Integration tests for load_cdc_records():
+  Local parquet on disk; S3 boundary functions patched to local equivalents.
+  Validates the full apply-CDC-to-fact pipeline end-to-end.
 
-  Tier 1 — cdc_to_fact() unit tests
-    Pure DataFrame logic; no I/O, no mocking.  Fast and precise.
-    These are the primary spec for CDC operation semantics and directly
-    pin the Bug 1 regression (pure-delete batches being no-op'd).
-
-  Tier 2 — load_cdc_records() integration tests
-    Local parquet on disk; S3 boundary functions patched to local equivalents.
-    Validates the full apply-CDC-to-fact pipeline end-to-end.
+Coverage includes:
+  - Single-operation batches (pure I, U, D)
+  - Mixed-operation batches (different keys)
+  - Same-key conflict resolution (I→U, D→I, D→U, multi-U sparse merge)
+  - B-record filtering
+  - Null-means-no-change sparse update semantics
 
 Assumptions documented by the test suite (per Qlik CDC spec §2.4.2):
   - A NULL value in a "U" record means "no change to this column", NOT
     "set this column to NULL".  This assumption is implicit in the code's
-    null-skipping filter and is pinned by test_cdc_to_fact_null_update_not_applied.
+    null-skipping filter and is pinned by test_load_cdc_null_update_not_applied.
 """
 
 import datetime
@@ -30,7 +30,6 @@ from odin.generate.cubic.ods_fact import (
     NEXT_RUN_DEFAULT,
     NEXT_RUN_LONG,
     CubicODSFact,
-    cdc_to_fact,
 )
 from odin.utils.aws.s3 import S3Object
 from odin.utils.parquet import ds_from_path
@@ -223,262 +222,7 @@ def run_load_cdc(job, tmp_path) -> int:
 
 
 # ===========================================================================
-# TIER 1 — cdc_to_fact() unit tests
-# ===========================================================================
-
-
-def test_cdc_to_fact_pure_inserts():
-    """I records land in insert_df; update_df and delete_df are empty."""
-    cdc = make_cdc_df(
-        [
-            {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "header__change_oper": "I"},
-            {"txn_id": 2, "amount": 200, "header__change_seq": "00002", "header__change_oper": "I"},
-        ]
-    )
-    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
-
-    assert ins.height == 2
-    assert set(ins["txn_id"].to_list()) == {1, 2}
-    assert upd.height == 0
-    assert dlt.height == 0
-
-
-def test_cdc_to_fact_pure_deletes():
-    """
-    D records land in delete_df; update_df must be EMPTY.
-
-    This is the direct regression test for Bug 1: before the fix, update_df
-    was seeded with all CDC keys regardless of operation, causing delete-only
-    batches to be silently no-op'd when applied to the fact table.
-    """
-    cdc = make_cdc_df(
-        [
-            {"txn_id": 1, "header__change_seq": "00001", "header__change_oper": "D"},
-            {"txn_id": 2, "header__change_seq": "00002", "header__change_oper": "D"},
-            {"txn_id": 3, "header__change_seq": "00003", "header__change_oper": "D"},
-        ]
-    )
-    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
-
-    assert ins.height == 0
-    assert upd.height == 0, (
-        f"update_df should be empty for pure-delete batch but has {upd.height} rows. "
-        "This indicates the Bug 1 fix is not applied: delete keys must not seed update_df."
-    )
-    assert dlt.height == 3
-    assert set(dlt["txn_id"].to_list()) == {1, 2, 3}
-
-
-def test_cdc_to_fact_pure_updates():
-    """U records build update_df with correct key + column values; others empty."""
-    cdc = make_cdc_df(
-        [
-            {
-                "txn_id": 1,
-                "amount": 999,
-                "status": "active",
-                "header__change_seq": "00001",
-                "header__change_oper": "U",
-            },
-        ]
-    )
-    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
-
-    assert ins.height == 0
-    assert dlt.height == 0
-    assert upd.height == 1
-    assert upd["txn_id"][0] == 1
-    assert upd["amount"][0] == 999
-    assert upd["status"][0] == "active"
-
-
-def test_cdc_to_fact_before_images_ignored():
-    """B records are fully ignored; all output DataFrames are empty."""
-    cdc = make_cdc_df(
-        [
-            {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "header__change_oper": "B"},
-            {"txn_id": 2, "amount": 200, "header__change_seq": "00002", "header__change_oper": "B"},
-        ]
-    )
-    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
-
-    assert ins.height == 0
-    assert upd.height == 0
-    assert dlt.height == 0
-
-
-def test_cdc_to_fact_update_latest_seq_wins():
-    """
-    When two U records target the same key, the one with the higher
-    header__change_seq wins per column (spec §2.4.3).
-    """
-    cdc = make_cdc_df(
-        [
-            {
-                "txn_id": 1,
-                "amount": 111,
-                "status": "old",
-                "header__change_seq": "00001",
-                "header__change_oper": "U",
-            },
-            {
-                "txn_id": 1,
-                "amount": 999,
-                "status": "new",
-                "header__change_seq": "00002",
-                "header__change_oper": "U",
-            },
-        ]
-    )
-    _, upd, _ = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
-
-    row = upd.filter(pl.col("txn_id") == 1)
-    assert row.height == 1
-    assert row["amount"][0] == 999
-    assert row["status"][0] == "new"
-
-
-def test_cdc_to_fact_null_update_not_applied():
-    """
-    A NULL value in a U record is treated as 'no change', not 'set to NULL'.
-
-    This pins the implicit assumption in the code (spec §2.4.2 note): the
-    pipeline lacks a change_mask and assumes the source never uses NULL to
-    mean 'set-to-NULL'.  If that assumption breaks, this test will need
-    revisiting alongside the apply logic.
-    """
-    cdc = make_cdc_df(
-        [
-            # amount is null — should not overwrite; status has a new value.
-            {
-                "txn_id": 1,
-                "amount": None,
-                "status": "changed",
-                "header__change_seq": "00001",
-                "header__change_oper": "U",
-            },
-        ]
-    )
-    _, upd, _ = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
-
-    assert upd.height == 1
-    assert upd["txn_id"][0] == 1
-    # amount column should not appear in update_df (null value was skipped)
-    assert "amount" not in upd.columns or upd["amount"][0] is None
-    assert upd["status"][0] == "changed"
-
-
-def test_cdc_to_fact_mixed_operations():
-    """I / U / D / B records in one batch each route to the correct DataFrame."""
-    cdc = make_cdc_df(
-        [
-            {
-                "txn_id": 10,
-                "amount": 100,
-                "header__change_seq": "00001",
-                "header__change_oper": "I",
-            },
-            {
-                "txn_id": 20,
-                "amount": 200,
-                "header__change_seq": "00002",
-                "header__change_oper": "U",
-            },
-            {"txn_id": 30, "header__change_seq": "00003", "header__change_oper": "D"},
-            {
-                "txn_id": 40,
-                "amount": 400,
-                "header__change_seq": "00004",
-                "header__change_oper": "B",
-            },
-        ]
-    )
-    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
-
-    assert set(ins["txn_id"].to_list()) == {10}
-    assert set(upd["txn_id"].to_list()) == {20}
-    assert set(dlt["txn_id"].to_list()) == {30}
-    # B record (txn_id=40) must not appear anywhere
-    for df in (ins, upd, dlt):
-        if df.height > 0:
-            assert 40 not in df["txn_id"].to_list()
-
-
-def test_cdc_to_fact_delete_then_insert_same_key():
-    """
-    A D followed by an I for the same key lands in delete_df AND insert_df.
-    update_df must not contain the key (no U records).
-    """
-    cdc = make_cdc_df(
-        [
-            {"txn_id": 1, "header__change_seq": "00001", "header__change_oper": "D"},
-            {"txn_id": 1, "amount": 999, "header__change_seq": "00002", "header__change_oper": "I"},
-        ]
-    )
-    ins, upd, dlt = cdc_to_fact(cdc, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
-
-    assert 1 in ins["txn_id"].to_list()
-    assert 1 in dlt["txn_id"].to_list()
-    assert upd.height == 0
-
-
-def test_cdc_to_fact_accumulation_across_batches():
-    """
-    Calling cdc_to_fact multiple times (simulating the fetch loop) accumulates
-    results correctly without double-counting.
-    """
-    batch1 = make_cdc_df(
-        [
-            {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "header__change_oper": "I"},
-            {"txn_id": 2, "amount": 200, "header__change_seq": "00002", "header__change_oper": "U"},
-        ]
-    )
-    batch2 = make_cdc_df(
-        [
-            {"txn_id": 3, "header__change_seq": "00003", "header__change_oper": "D"},
-            {"txn_id": 4, "amount": 400, "header__change_seq": "00004", "header__change_oper": "I"},
-        ]
-    )
-
-    ins, upd, dlt = cdc_to_fact(batch1, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
-    ins, upd, dlt = cdc_to_fact(batch2, ins, upd, dlt, KEYS)
-
-    assert set(ins["txn_id"].to_list()) == {1, 4}
-    # update_df accumulates keys from U records only
-    assert set(upd["txn_id"].to_list()) == {2}
-    assert set(dlt["txn_id"].to_list()) == {3}
-
-
-def test_cdc_to_fact_accumulation_deletes_do_not_pollute_updates():
-    """
-    Across multiple batches, D records in a subsequent batch must not add
-    keys to update_df (the specific multi-batch form of Bug 1).
-    """
-    batch1 = make_cdc_df(
-        [
-            {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "header__change_oper": "U"},
-        ]
-    )
-    batch2 = make_cdc_df(
-        [
-            {"txn_id": 2, "header__change_seq": "00002", "header__change_oper": "D"},
-            {"txn_id": 3, "header__change_seq": "00003", "header__change_oper": "D"},
-        ]
-    )
-
-    ins, upd, dlt = cdc_to_fact(batch1, pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), KEYS)
-    ins, upd, dlt = cdc_to_fact(batch2, ins, upd, dlt, KEYS)
-
-    # update_df should only contain txn_id=1 (from the U in batch 1)
-    assert set(upd["txn_id"].to_list()) == {1}, (
-        f"update_df contains unexpected keys {upd['txn_id'].to_list()}. "
-        "Delete keys from batch2 must not be merged into update_df."
-    )
-    assert set(dlt["txn_id"].to_list()) == {2, 3}
-
-
-# ===========================================================================
-# TIER 2 — load_cdc_records() integration tests
+# load_cdc_records() integration tests
 # ===========================================================================
 
 
@@ -718,3 +462,383 @@ def test_load_cdc_mixed_operations(cdc_integration, tmp_path):
     assert set(fact["txn_id"].to_list()) == {1, 2, 4}
     assert fact.filter(pl.col("txn_id") == 2)["amount"][0] == 999
     assert fact.filter(pl.col("txn_id") == 1)["amount"][0] == 100  # unchanged
+
+
+# ===========================================================================
+# Same-key conflict resolution tests
+# ===========================================================================
+
+
+def test_load_cdc_insert_then_update_same_key(cdc_integration, tmp_path):
+    """
+    I→U for the same key in one batch: the row must survive with the I record
+    as the base and the U columns applied on top.
+
+    This is the I→U bug regression test.  Before the fix, the update path
+    looked for an existing fact row (which doesn't exist — the key was just
+    inserted), found nothing, and silently dropped the row.
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "odin_index": 0},
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {
+                    "txn_id": 5,
+                    "amount": 500,
+                    "status": "initial",
+                    "header__change_seq": "00010",
+                    "header__change_oper": "I",
+                },
+                {
+                    "txn_id": 5,
+                    "amount": 555,
+                    "header__change_seq": "00011",
+                    "header__change_oper": "U",
+                },
+            ]
+        )
+    )
+
+    run_load_cdc(job, tmp_path)
+
+    fact = read_fact()
+    assert fact.height == 2, (
+        f"Expected 2 rows (original + I→U), got {fact.height}. "
+        "If 1, the I→U row was silently dropped."
+    )
+    assert set(fact["txn_id"].to_list()) == {1, 5}
+    row5 = fact.filter(pl.col("txn_id") == 5)
+    assert row5["amount"][0] == 555, "U column should overwrite I base value"
+    assert row5["status"][0] == "initial", "Non-updated columns should retain I base value"
+
+
+def test_load_cdc_insert_then_multiple_updates_same_key(cdc_integration, tmp_path):
+    """
+    I→U→U for the same key: both sparse U records contribute column values
+    on top of the I base row.
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "odin_index": 0},
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {
+                    "txn_id": 5,
+                    "amount": 500,
+                    "status": "initial",
+                    "header__change_seq": "00010",
+                    "header__change_oper": "I",
+                },
+                {
+                    "txn_id": 5,
+                    "amount": 555,
+                    "header__change_seq": "00011",
+                    "header__change_oper": "U",
+                },
+                {
+                    "txn_id": 5,
+                    "status": "final",
+                    "header__change_seq": "00012",
+                    "header__change_oper": "U",
+                },
+            ]
+        )
+    )
+
+    run_load_cdc(job, tmp_path)
+
+    fact = read_fact()
+    assert fact.height == 2
+    row5 = fact.filter(pl.col("txn_id") == 5)
+    assert row5["amount"][0] == 555, "Latest U for amount should win"
+    assert row5["status"][0] == "final", "Latest U for status should win"
+
+
+def test_load_cdc_delete_then_insert_same_key(cdc_integration, tmp_path):
+    """
+    D→I for the same key: the old row is removed and the new I row is inserted.
+    Final op is I, so the insert record is used directly.
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 100,
+                    "status": "old",
+                    "header__change_seq": "00001",
+                    "odin_index": 0,
+                },
+                {"txn_id": 2, "amount": 200, "header__change_seq": "00002", "odin_index": 1},
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {"txn_id": 1, "header__change_seq": "00010", "header__change_oper": "D"},
+                {
+                    "txn_id": 1,
+                    "amount": 999,
+                    "status": "reinserted",
+                    "header__change_seq": "00011",
+                    "header__change_oper": "I",
+                },
+            ]
+        )
+    )
+
+    run_load_cdc(job, tmp_path)
+
+    fact = read_fact()
+    assert fact.height == 2
+    assert set(fact["txn_id"].to_list()) == {1, 2}
+    row1 = fact.filter(pl.col("txn_id") == 1)
+    assert row1["amount"][0] == 999
+    assert row1["status"][0] == "reinserted"
+
+
+def test_load_cdc_delete_then_update_same_key(cdc_integration, tmp_path):
+    """
+    D→U for the same key (key exists in fact): final op is U, so the existing
+    fact row is fetched and the sparse U columns applied.  The intermediate D
+    is effectively overridden.
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 100,
+                    "status": "old",
+                    "header__change_seq": "00001",
+                    "odin_index": 0,
+                },
+                {"txn_id": 2, "amount": 200, "header__change_seq": "00002", "odin_index": 1},
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {"txn_id": 1, "header__change_seq": "00010", "header__change_oper": "D"},
+                {
+                    "txn_id": 1,
+                    "status": "updated",
+                    "header__change_seq": "00011",
+                    "header__change_oper": "U",
+                },
+            ]
+        )
+    )
+
+    run_load_cdc(job, tmp_path)
+
+    fact = read_fact()
+    assert fact.height == 2
+    assert set(fact["txn_id"].to_list()) == {1, 2}
+    row1 = fact.filter(pl.col("txn_id") == 1)
+    assert row1["amount"][0] == 100, "Non-updated columns retain original value"
+    assert row1["status"][0] == "updated"
+
+
+def test_load_cdc_multiple_updates_sparse_columns(cdc_integration, tmp_path):
+    """
+    Two U records for the same key updating different columns: both column
+    values are applied (latest non-null per column wins).
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 100,
+                    "status": "old",
+                    "header__change_seq": "00001",
+                    "odin_index": 0,
+                },
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 999,
+                    "header__change_seq": "00010",
+                    "header__change_oper": "U",
+                },
+                {
+                    "txn_id": 1,
+                    "status": "new",
+                    "header__change_seq": "00011",
+                    "header__change_oper": "U",
+                },
+            ]
+        )
+    )
+
+    run_load_cdc(job, tmp_path)
+
+    fact = read_fact()
+    assert fact.height == 1
+    row1 = fact.filter(pl.col("txn_id") == 1)
+    assert row1["amount"][0] == 999, "amount from first U should be applied"
+    assert row1["status"][0] == "new", "status from second U should be applied"
+
+
+def test_load_cdc_null_update_not_applied(cdc_integration, tmp_path):
+    """
+    A NULL value in a U record means 'no change', not 'set to NULL'.
+
+    Pins the implicit assumption (Qlik CDC spec §2.4.2): the pipeline lacks a
+    change_mask and treats NULL in U records as 'column not touched'.
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 100,
+                    "status": "original",
+                    "header__change_seq": "00001",
+                    "odin_index": 0,
+                },
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": None,
+                    "status": "changed",
+                    "header__change_seq": "00010",
+                    "header__change_oper": "U",
+                },
+            ]
+        )
+    )
+
+    run_load_cdc(job, tmp_path)
+
+    fact = read_fact()
+    assert fact.height == 1
+    row1 = fact.filter(pl.col("txn_id") == 1)
+    assert row1["amount"][0] == 100, "NULL in U record should not overwrite existing value"
+    assert row1["status"][0] == "changed"
+
+
+def test_load_cdc_before_images_filtered(cdc_integration, tmp_path):
+    """
+    B (before-image) records in the history are filtered out by the CDC filter
+    and do not affect the fact table.
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {"txn_id": 1, "amount": 100, "header__change_seq": "00001", "odin_index": 0},
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {
+                    "txn_id": 2,
+                    "amount": 200,
+                    "header__change_seq": "00010",
+                    "header__change_oper": "B",
+                },
+                {
+                    "txn_id": 3,
+                    "amount": 300,
+                    "header__change_seq": "00011",
+                    "header__change_oper": "I",
+                },
+            ]
+        )
+    )
+
+    run_load_cdc(job, tmp_path)
+
+    fact = read_fact()
+    assert fact.height == 2
+    assert set(fact["txn_id"].to_list()) == {1, 3}, "B record (txn_id=2) must not appear"
+
+
+def test_load_cdc_update_latest_seq_wins(cdc_integration, tmp_path):
+    """
+    When two U records target the same key and same column, the one with the
+    higher header__change_seq wins (spec §2.4.3).
+    """
+    job, write_fact, write_history, read_fact = cdc_integration
+
+    write_fact(
+        make_fact_df(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 100,
+                    "status": "old",
+                    "header__change_seq": "00001",
+                    "odin_index": 0,
+                },
+            ]
+        )
+    )
+    write_history(
+        make_cdc_df(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 111,
+                    "status": "first",
+                    "header__change_seq": "00010",
+                    "header__change_oper": "U",
+                },
+                {
+                    "txn_id": 1,
+                    "amount": 999,
+                    "status": "second",
+                    "header__change_seq": "00011",
+                    "header__change_oper": "U",
+                },
+            ]
+        )
+    )
+
+    run_load_cdc(job, tmp_path)
+
+    fact = read_fact()
+    assert fact.height == 1
+    row1 = fact.filter(pl.col("txn_id") == 1)
+    assert row1["amount"][0] == 999
+    assert row1["status"][0] == "second"


### PR DESCRIPTION
### Background
`ods_fact.py` has historically maintained 3 separate accumulators (`insert_df`, `update_df`, `delete_df`) for cdc operations that are incrementally built via `cdc_to_fact()`. This interleaved approach made it difficult to reason about operation conflicts, which, combined with a complete lack of unit tests, led to a bug where keys that were updated and subsequently deleted in an update batch were getting reinserted after the delete, which we saw impact the data in the unsettled transactions fact tables.

### Solution
This PR does 2 things to address this and prevent similar errors from being reintroduced in the future:

1. introduces a simplified structure for `load_cdc_records()` by accumulating all CDC records as raw data first, then resolving each key to its final operation (I/U/D) in one pass
2. introduces a test suite (in collaboration with @MaxAlex)

Here is the order of operations for the new structure (per the new docstring):

```
Order of operations:
  1. Read the current fact table and its max header__change_seq.
  2. Pull CDC records (I/U/D) from history with seq > max_fact_seq.
     Repeat in a loop to accumulate enough work.
  3. For every key touched by CDC, determine the FINAL operation:
     sort all CDC records by header__change_seq descending, deduplicate
     by key keeping the latest. The latest oper wins.
  4. Build a single "new_rows" dataframe:
     - For keys whose final op is I: use the I record directly.
     - For keys whose final op is U: fetch the existing fact row, apply
       the sparse column updates, produce an updated row.  If no fact
       row exists (I→U in same batch), use the I record as the base.
     - For keys whose final op is D: no new row (just drop the old one).
  5. Collect odin_index values of all fact rows being replaced or deleted
     (any key in the CDC batch that already exists in fact_ds).
  6. Write: filter old dataset to exclude touched rows, union with new_rows,
     upload to S3.
```

Important to note: since updates are sparse (not every column need be updated at once), when the final operation is U, all updates are applied in sequence. If a key is inserted and updated within a single batch, the insert acts as a base for the subsequent updates. When I or D operations are last, only the last operation for this key need be applied.

### Post-deploy operations
- [ ] Audit tables to determine which were affected
- [ ] Trigger a full snapshot reload for each affected table via migration
- [ ] Update downstream users on status


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214063772751888