### PR TITLE
feat: Adding logging to AFCArchive

### DIFF
--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -402,12 +402,16 @@ class ArchiveAFCAPI(OdinJob):
 
         API data will be downloaded in batches to limit API reponse time.
         """
+        log = ProcessLog("load_job_ids", table=self.table, pq_job_id=self.pq_job_id)
         # assume 12 bytes per column to ballbark 50mb per request
         min_disk_free_pct = 60
         target_rows = int(50 * 1024 * 1024 / (12 * self.schema.len()))
         download_jobs: APICounts = []
         download_rows = 0
+        api_max_job_id = 0
+        stopped_early = False
         for job_ids in self.api_job_ids(self.pq_job_id):
+            api_max_job_id = max(api_max_job_id, job_ids[-1]["jobId"])
             for api_job in job_ids:
                 # extra check to make certain jobId should be processed
                 if int(api_job["jobId"]) <= int(self.pq_job_id):
@@ -421,13 +425,20 @@ class ArchiveAFCAPI(OdinJob):
                     download_rows = 0
                 # stop if disk is getting too full
                 if disk_free_pct() < min_disk_free_pct:
+                    stopped_early = True
                     break
             if len(download_jobs) > 0:
                 self.download_json(download_jobs)
 
             # This is ugly, but should work for now...
             if disk_free_pct() < min_disk_free_pct:
+                stopped_early = True
                 break
+        log.complete(
+            api_max_job_id=api_max_job_id,
+            max_job_id=self.max_job_id,
+            stopped_early=stopped_early,
+        )
 
     def sync_parquet(self) -> None:
         """Convert json to parquet and sync with S3 files."""
@@ -490,7 +501,7 @@ class ArchiveAFCAPI(OdinJob):
 
     def re_run_check(self) -> int:
         """
-        Determine when job should be ru-run.
+        Determine when job should be re-run.
 
         If `count` returning more than 1 job, based on self.max_job_id, more jobs available.
         """
@@ -501,8 +512,15 @@ class ArchiveAFCAPI(OdinJob):
                 url=f"{API_ROOT}/count",
                 fields={"table_name": self.table, "jobIdFrom": str(self.max_job_id)},
             )
-            if len(r.json()) > 1:
+            remaining_jobs: APICounts = r.json()
+            remaining_count = len(remaining_jobs)
+            if remaining_count > 1:
                 return_duration = 60 * 5
+            api_latest_job_id = max((j["jobId"] for j in remaining_jobs), default=0)
+            log.add_metadata(
+                remaining_job_count=remaining_count,
+                api_latest_job_id=api_latest_job_id,
+            )
         log.complete(return_duration=return_duration)
         return return_duration
 


### PR DESCRIPTION
This PR adds some additional logging to `load_job_ids()` and `re_run_check()`. Previously, only `pq_job_id` was logged, which tracks the highest job_id in existing parquet export file, leaving us with now way to retroactively check API data availability and less ability to troubleshoot. This PR does not touch any of the update logic, and logs fire off correctly when testing locally.

Logging added to `load_job_ids`:
- `pq_job_id`: highest job_id in existing parquet export file
- `api_max_job_id`: highest job_id seen from `/count` endpoint during this run
- `max_job_id`: highest job_id actually downloaded
- `stopped_early`: if true, `load_job_ids` stopped early due to low disk space (compared to `min_disk_free_pct`, currently set to `60`)

Logging added to `re_run_check`:
- `remaining_job_count`: jobs the API reports beyond what was downloaded
- `api_latest_job_id`: highest job_id available from the API post-download
