### PR TITLE
chore: Updating wc320_late_tap_adjustment to remove transaction_histo…

### DIFF
--- a/src/odin/generate/data_dictionary/sql/mat_views/wc320_late_tap_adjustment.sql
+++ b/src/odin/generate/data_dictionary/sql/mat_views/wc320_late_tap_adjustment.sql
@@ -26,13 +26,13 @@ JOIN
         u.patron_trip_id = tp.patron_trip_id
         AND u.trip_price_count = tp.trip_price_count
 LEFT JOIN
-    cubic_ods.edw_transaction_history en
+    cubic_ods.edw_operator_dimension eod
     ON
-        en.dw_transaction_id = t.dw_entry_txn_id
+        eod.operator_key = u.operator_key
 LEFT JOIN
     cubic_ods.edw_travel_mode_dimension tm
     ON
-        tm.travel_mode_id = en.travel_mode_id
+        tm.travel_mode_id = eod.travel_mode_id
 WHERE
     s.sale_type_key = 26
     AND u.value_changed <> 0


### PR DESCRIPTION
…ry and improve performance

The primary benefit is that this allows us to remove the transaction_history table from our sync list. But I have also verified that the new query is an improvement on the old, including:
- the new version doesn't have any null values in travel_mode_name (vs 134 null rows in the original)
- it is also faster to materialize (7.9s vs 46.8s)

Asana: https://app.asana.com/1/15492006741476/project/1210977089884035/task/1214080340553531?focus=true