### PR TITLE
fix: remove CERT_NONE flag from masabi urllib pool

### DIFF
--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -410,18 +410,10 @@ class ArchiveMasabi(OdinJob):
 
     def _make_request_pool(self) -> urllib3.PoolManager:
         """Build a urllib3 connection pool with Masabi basic-auth headers."""
-        # TODO: REMOVE 'cert_reqs="CERT_NONE"' BEFORE PRODUCTION RELEASE.
-        # SSL certificate verification is disabled here solely to support local
-        # development and testing against UAT endpoints. Leaving this in place
-        # for a production deployment is a serious security risk — it makes the
-        # connection vulnerable to man-in-the-middle attacks. Remove this flag
-        # (and the disable_warnings call below) once proper certs are in place.
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         return urllib3.PoolManager(
             headers=urllib3.make_headers(basic_auth=f"{_API_USERNAME}:{_API_PASSWORD}"),
             timeout=urllib3.Timeout(total=60 * 10),
             retries=False,
-            cert_reqs="CERT_NONE",
         )
 
     def _make_request(


### PR DESCRIPTION
Asana ticket: https://app.asana.com/1/15492006741476/project/1212830297996795/task/1213877775425747?focus=true

Was originally put in to avoid a certificate error encountered during local testing. I'm fairly certain it was zscaler-related, so it shouldn't ever effect dev or prod, but it's worth testing that out sooner than later.