### PR TITLE
chore: Disabling Tableau upload until gateway connection issues resolved

### DIFF
--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -18,7 +18,7 @@ from odin.ingestion.afc.afc_archive import schedule_afc_archive
 from odin.ingestion.afc.afc_restricted import schedule_restricted_afc_archive
 from odin.ingestion.masabi.masabi_archive import schedule_masabi_archive
 from odin.generate.data_dictionary.dictionary import schedule_dictionary
-from odin.ingestion.tableau.tableau_upload import schedule_tableau_upload
+# from odin.ingestion.tableau.tableau_upload import schedule_tableau_upload
 
 
 def start():
@@ -78,7 +78,8 @@ def start():
         schedule_masabi_archive(schedule)
     if "data_dictionary" in config:
         schedule_dictionary(schedule)
-    if "tableau_upload" in config:
-        schedule_tableau_upload(schedule)
+    # Tableau upload disabled until gateway connection issues are resolved
+    # if "tableau_upload" in config:
+    #     schedule_tableau_upload(schedule)
 
     schedule.run()


### PR DESCRIPTION
Disabling Tableau upload until gateway connection issues resolved, as Odin cannot currently reach the on-prem server, and the cloud server has been abandoned