### PR TITLE
Fix: Top level logging start-complete for all jobs

### DIFF
--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -583,6 +583,7 @@ class CubicODSFact(OdinJob):
          - Merge CDC FACT conversion with existing FACT S3 dataset.
          - Upload merged FACT files to S3.
         """
+        log = ProcessLog("CubicODSFact", table=self.table)
         self.start_kwargs = {"table": self.table}
         next_run_secs = NEXT_RUN_DEFAULT
 
@@ -612,12 +613,16 @@ class CubicODSFact(OdinJob):
                 )
                 snapshot_compare_to_history.complete()
             next_run_secs = self.load_cdc_records()
+
+            log.complete(run_interval=next_run_secs)
         # For development, other ODIN running...
-        except pa.ArrowInvalid:
+        except pa.ArrowInvalid as e:
             self.start_kwargs["other_odin_running"] = "True"
+            log.failed(exception=e)
             return NEXT_RUN_IMMEDIATE
-        except NoQlikHistoryError:
+        except NoQlikHistoryError as e:
             self.start_kwargs["no_qlik_history_available"] = "True"
+            log.failed(exception=e)
 
         return next_run_secs
 

--- a/src/odin/generate/data_dictionary/dictionary.py
+++ b/src/odin/generate/data_dictionary/dictionary.py
@@ -159,6 +159,7 @@ class DataDictionary(OdinJob):
             ]
         }
         """
+        log = ProcessLog("DataDictionary")
         # Create and upload Data Dictionary json file.
         column_descriptions = fetch_AFC_column_descriptions()
         data_dictionary = [
@@ -187,6 +188,7 @@ class DataDictionary(OdinJob):
         upload_path = os.path.join(DATA_SPRINGBOARD, ODIN_DICTIONARY, db_obj_name)
         upload_file(db_file, upload_path)
 
+        log.complete(run_interval=NEXT_RUN_DEFAULT)
         return NEXT_RUN_DEFAULT
 
 

--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -560,6 +560,7 @@ class ArchiveAFCAPI(OdinJob):
         May 12, 2025 - API has been updated to always return results from "count" endpoint.
         June 2, 2025 - Updated to handle "static" and "transactional" table types.
         """
+        log = ProcessLog("ArchiveAFCAPI", table=self.table)
         self.start_kwargs = {"table": self.table}
         # Current timetout set to 10 mins, for full PROD deployment should be no more than 2 mins.
         self.req_pool = urllib3.PoolManager(
@@ -571,6 +572,7 @@ class ArchiveAFCAPI(OdinJob):
         self.load_job_ids()
         next_run_duration = self.re_run_check()
         self.sync_parquet()
+        log.complete(run_interval=next_run_duration)
         return next_run_duration
 
 

--- a/src/odin/ingestion/qlik/cubic_archive.py
+++ b/src/odin/ingestion/qlik/cubic_archive.py
@@ -340,6 +340,7 @@ class ArchiveCubicQlikTable(OdinJob):
             - if backlog of cdc files exists -> 5 mins
                 * when cdc files > half of max_cdc_files requested
         """
+        log = ProcessLog("ArchiveCubicQlikTable", table=self.table)
         try:
             self.start_kwargs = {"table": self.table, "save_local": self.save_local}
             self.archive_objects: List[str] = []
@@ -356,9 +357,11 @@ class ArchiveCubicQlikTable(OdinJob):
             self.load_cdc(cdc_files)
             self.move_objects()
 
-        except RecentSnapshotError:
+            log.complete(run_interval=next_run_secs)
+        except RecentSnapshotError as e:
             self.start_kwargs["skipped_recent_snapshot"] = True
             next_run_secs = NEXT_RUN_DEFAULT
+            log.failed(exception=e)
 
         return next_run_secs
 


### PR DESCRIPTION
There are currently no particular log messages that consistently mark the beginning and end of jobs, making it difficult to determine how much time individual jobs or tables are taking. This adds a top-level log for every job that didn't previously have one, which is guaranteed to always emit a failed or complete message.