### PR TITLE
Fix: Add numeric override for validation.telemetry

### DIFF
--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -96,6 +96,7 @@ TABLE_NUMERIC_OVERRIDES: dict[str, frozenset[str]] = {
     "retail.tickets": frozenset({"hourOfDay"}),
     "retail.rider_entitlement_events": frozenset({"hourOfDay"}),
     "validation.scans": frozenset({"hourOfDay"}),
+    "validation.telemetry": frozenset({"hourOfDay"}),
 }
 
 TABLE_TIMESTAMP_OVERRIDES: dict[str, str] = {


### PR DESCRIPTION
validation.telemetry in the Masabi data has the same incorrectly typed hourOfDay column as a bunch of others.