### PR TITLE
Adding old entitlement data for migration

### DIFF
--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -82,6 +82,7 @@ API_TABLES = [
     "v_transit_accounts",
     "v_payment_methods",
     "v_entitlements",
+    "v_entitlements_full",  # temporary full snapshot export containing older data
     "v_payment_method_instances",
     "v_products",
 ]


### PR DESCRIPTION
The table containing the running log of changes for entitlements (`v_entitlements`) doesn't go back as far as is needed, and S&B can only send us a snapshot of the full version. This adds `v_entitlements_full`, which should download as usual and will be used in a future migration which will handle the merge logic. There are some important differences between the formats for `v_entitlements_full` and `v_entitlements`, and they have different job_ids, so verify these details before determining how to merge.

Needed for https://app.asana.com/1/15492006741476/project/1213716198445326/task/1214685376323207?focus=true