### PR TITLE
Add Masabi restricted schema data

### DIFF
--- a/src/odin/generate/data_dictionary/duck_db.py
+++ b/src/odin/generate/data_dictionary/duck_db.py
@@ -15,6 +15,7 @@ from odin.utils.locations import AFC_DATA
 from odin.utils.locations import AFC_RESTRICTED
 from odin.utils.locations import CUBIC_ODS_REPORTS
 from odin.utils.locations import MASABI_DATA
+from odin.utils.locations import MASABI_RESTRICTED
 from odin.utils.parquet import ds_from_path
 
 
@@ -68,6 +69,13 @@ dataset_views = [
     ViewBuilder(
         s3_prefix=os.path.join(DATA_SPRINGBOARD, MASABI_DATA),
         schema="masabi",
+        template=Template(
+            f"{DROP_VIEW} CREATE VIEW $schema.$table AS SELECT $columns FROM {READ_PQ};"
+        ),
+    ),
+    ViewBuilder(
+        s3_prefix=os.path.join(DATA_SPRINGBOARD, MASABI_RESTRICTED),
+        schema="masabi_restricted",
         template=Template(
             f"{DROP_VIEW} CREATE VIEW $schema.$table AS SELECT $columns FROM {READ_PQ};"
         ),

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -157,6 +157,13 @@ TABLE_PII_DROP_COLUMNS: dict[str, list[str]] = {
     "view.validators": ["username"],
 }
 
+TABLE_PII_RESTRICTED_ALLOWED: dict[str, list[str]] = {
+    "retail.rider_entitlement_events": ["proofId"],
+    "retail.activations": ["location"],
+    "retail.ticket_purchases": ["location"],
+    "validation.scans": ["location"],
+    "validation.telemetry": ["location"],
+}
 
 # ---------------------------------------------------------------------------
 # Schema Retrieval
@@ -767,10 +774,10 @@ class ArchiveMasabi(OdinJob):
         to_ts = int(time.time() * 1000)
 
         schema = TABLE_SCHEMAS.get(self.table)
+        exclude_cols = TABLE_PII_DROP_COLUMNS.get(self.table, [])
         if self.restricted:
-            exclude_cols = []
-        else:
-            exclude_cols = TABLE_PII_DROP_COLUMNS.get(self.table, [])
+            restricted_allowed = TABLE_PII_RESTRICTED_ALLOWED.get(self.table, [])
+            exclude_cols = [x for x in exclude_cols if x not in restricted_allowed]
         if schema is not None:
             schema = pl.Schema([(x, schema[x]) for x in schema if x not in exclude_cols])
 

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -12,7 +12,7 @@ import pyarrow.parquet as pq
 
 from odin.utils.logger import ProcessLog
 from odin.job import OdinJob, job_proc_schedule
-from odin.utils.locations import DATA_SPRINGBOARD, MASABI_DATA
+from odin.utils.locations import DATA_SPRINGBOARD, MASABI_DATA, MASABI_RESTRICTED
 from odin.utils.aws.s3 import s3_folder
 from odin.utils.aws.s3 import download_object
 from odin.utils.aws.s3 import list_objects
@@ -473,11 +473,15 @@ class SchemaCheck:
 class ArchiveMasabi(OdinJob):
     """Basic Odin job stub for Masabi ingestion."""
 
-    def __init__(self, table: str) -> None:
+    def __init__(self, table: str, restricted: bool = False) -> None:
         """Create Job instance."""
         self.table = table
+        self.restricted = restricted
         self.start_kwargs = {"table": table}
-        self.export_folder = s3_folder(os.path.join(DATA_SPRINGBOARD, MASABI_DATA, table))
+        if restricted:
+            self.export_folder = s3_folder(os.path.join(DATA_SPRINGBOARD, MASABI_RESTRICTED, table))
+        else:
+            self.export_folder = s3_folder(os.path.join(DATA_SPRINGBOARD, MASABI_DATA, table))
         self._last_request_time: float = 0.0
 
     def _make_request_pool(self) -> urllib3.PoolManager:
@@ -763,7 +767,10 @@ class ArchiveMasabi(OdinJob):
         to_ts = int(time.time() * 1000)
 
         schema = TABLE_SCHEMAS.get(self.table)
-        exclude_cols = TABLE_PII_DROP_COLUMNS.get(self.table, [])
+        if self.restricted:
+            exclude_cols = []
+        else:
+            exclude_cols = TABLE_PII_DROP_COLUMNS.get(self.table, [])
         if schema is not None:
             schema = pl.Schema([(x, schema[x]) for x in schema if x not in exclude_cols])
 
@@ -797,3 +804,6 @@ def schedule_masabi_archive(schedule: sched.scheduler) -> None:
     for table in TABLES:
         job = ArchiveMasabi(table)
         schedule.enter(0, 1, job_proc_schedule, (job, schedule))
+        if table in TABLE_PII_DROP_COLUMNS:
+            restricted_job = ArchiveMasabi(table, True)
+            schedule.enter(0, 1, job_proc_schedule, (restricted_job, schedule))

--- a/src/odin/utils/locations.py
+++ b/src/odin/utils/locations.py
@@ -30,3 +30,4 @@ AFC_RESTRICTED = f"{ODIN_DATA}/sb/restricted"
 
 # Masabi
 MASABI_DATA = f"{ODIN_DATA}/masabi/api"
+MASABI_RESTRICTED = f"{ODIN_DATA}/masabi/restricted"


### PR DESCRIPTION
Asana ticket: https://app.asana.com/1/15492006741476/project/1212830297996795/task/1214710854658380?focus=true

Adds a mode to the ArchiveMasabi writer that writes data with the restricted-allowed PII columns to a separate restricted masabi data path, and a new ViewBuilder instance that brings that data into the catalog.

This should go in with the corresponding devops PR: https://github.com/mbta/devops/pull/4370

