### PR TITLE
Fixes to restricted schema logic

### DIFF
--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -811,6 +811,6 @@ def schedule_masabi_archive(schedule: sched.scheduler) -> None:
     for table in TABLES:
         job = ArchiveMasabi(table)
         schedule.enter(0, 1, job_proc_schedule, (job, schedule))
-        if table in TABLE_PII_DROP_COLUMNS:
+        if table in TABLE_PII_RESTRICTED_ALLOWED:
             restricted_job = ArchiveMasabi(table, True)
             schedule.enter(0, 1, job_proc_schedule, (restricted_job, schedule))

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -121,6 +121,7 @@ TABLE_PII_DROP_COLUMNS: dict[str, list[str]] = {
         "cardSignature",
         "email",
         "ipAddress",
+        "location",
         "panFirstSix",
         "panLastFour",
         "salesAgent",


### PR DESCRIPTION
- Run restricted-mode ingestion only for tables that have restricted-allowed columns, not all tables that have PII
- "location" was missing from the PII list for retail.ticket_purchases, even though it was on the restricted-allowed list 