### PR TITLE
Fix: Correct column name in WA160

### DIFF
--- a/src/odin/generate/data_dictionary/sql/views/wa160.sql
+++ b/src/odin/generate/data_dictionary/sql/views/wa160.sql
@@ -59,7 +59,7 @@ SELECT
     coalesce(ut.refundable_purse_value, 0) as refundable_purse_value,
     coalesce(ut.uncollectible_amount, 0)::double / 100 as uncollectible_amount,
     tad.is_registered,
-    coalesce(ut.discount_amount, 0)::double / 100 AS discount_amount,
+    coalesce(ut.discount_applied, 0)::double / 100 AS discount_amount,
     coalesce(ut.post_pay_amount, 0)::double / 100 AS post_pay_amount
 FROM
     cubic_ods.edw_use_transaction ut


### PR DESCRIPTION
Matching the fix on DMAP: fixing the new column name in WA160.