### PR TITLE
chore: Increase Masabi maximum rows per run

### DIFF
--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -42,7 +42,7 @@ _SCHEMA_URL = os.getenv("MASABI_DATA_SCHEMA_URL", "")
 
 # Maximum update size: Adjust to match the maximum size that can be safely handled
 # by the ECS environment's RAM and disk resources.
-MAXIMUM_ROWS_PER_RUN = 10001
+MAXIMUM_ROWS_PER_RUN = 100001
 
 # Retry config for individual API page requests.
 # On a non-200 response or network error, the request is retried up to


### PR DESCRIPTION
Increasing the row limit so that we'll catch up faster.