### PR TITLE
Temporarily restricted schema updates (and shorter immediate re-run)

### DIFF
--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -55,7 +55,7 @@ API_MIN_REQUEST_INTERVAL_S: float = 1.0
 
 # Rescheduling time intervals
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
-NEXT_RUN_IMMEDIATE = 60 * 5  # 5 minutes
+NEXT_RUN_IMMEDIATE = 60  # 1 minute
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
 # Exclusive lower bound for the initial historical backfill: 2020-01-01 00:00:00 UTC (ms).
@@ -799,6 +799,6 @@ def schedule_masabi_archive(schedule: sched.scheduler) -> None:
     for table in TABLES_INSTANCE:
         job = ArchiveMasabi(table)
         schedule.enter(0, 1, job_proc_schedule, (job, schedule))
-        if table in TABLE_PII_RESTRICTED_ALLOWED:
-            restricted_job = ArchiveMasabi(table, True)
-            schedule.enter(0, 1, job_proc_schedule, (restricted_job, schedule))
+        # if table in TABLE_PII_RESTRICTED_ALLOWED:
+        #     restricted_job = ArchiveMasabi(table, True)
+        #     schedule.enter(0, 1, job_proc_schedule, (restricted_job, schedule))


### PR DESCRIPTION
Disabling the restricted schema updates so that the main tables catch up faster.

Also shortening NEXT_RUN_IMMEDIATE; we may run into a case where there's only one or two of the largest tables left catching up, which would mean that Odin-beta wouldn't saturate with a five-minute delay.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215397953195070