### PR TITLE
chore: reenabling restricted masabi tables

### DIFF
--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -799,6 +799,6 @@ def schedule_masabi_archive(schedule: sched.scheduler) -> None:
     for table in TABLES_INSTANCE:
         job = ArchiveMasabi(table)
         schedule.enter(0, 1, job_proc_schedule, (job, schedule))
-        # if table in TABLE_PII_RESTRICTED_ALLOWED:
-        #     restricted_job = ArchiveMasabi(table, True)
-        #     schedule.enter(0, 1, job_proc_schedule, (restricted_job, schedule))
+        if table in TABLE_PII_RESTRICTED_ALLOWED:
+            restricted_job = ArchiveMasabi(table, True)
+            schedule.enter(0, 1, job_proc_schedule, (restricted_job, schedule))


### PR DESCRIPTION
Now that the non-restricted masabi tables are caught up, reenabling the restricted versions