### PR TITLE
Fix masabi parquet rollover error

### DIFF
--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -55,7 +55,7 @@ API_MIN_REQUEST_INTERVAL_S: float = 1.0
 
 # Rescheduling time intervals
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
-NEXT_RUN_IMMEDIATE = 1  # 1 minute  ## TESTING
+NEXT_RUN_IMMEDIATE = 1  # 1 minute  ### TESTING
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
 # Exclusive lower bound for the initial historical backfill: 2020-01-01 00:00:00 UTC (ms).

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -42,7 +42,7 @@ _SCHEMA_URL = os.getenv("MASABI_DATA_SCHEMA_URL", "")
 
 # Maximum update size: Adjust to match the maximum size that can be safely handled
 # by the ECS environment's RAM and disk resources.
-MAXIMUM_ROWS_PER_RUN = 101
+MAXIMUM_ROWS_PER_RUN = 10001
 
 # Retry config for individual API page requests.
 # On a non-200 response or network error, the request is retried up to
@@ -725,7 +725,9 @@ class ArchiveMasabi(OdinJob):
             source=ds_from_path(sync_paths),
             export_folder=local_dir,
             export_file_prefix="table",
-            mb_per_file=1,  # For testing only!
+            mb_per_file=0,  # For testing only!
+            mb_per_group_disk=1,
+            mb_per_group_mem=1
         )
 
         # Perform S3 upload after sigterm check — uploads cannot be rolled back.

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -727,9 +727,6 @@ class ArchiveMasabi(OdinJob):
             export_file_prefix="table",
         )
 
-        if len(new_paths) > 1:
-            raise NotImplementedError("Fix for parquet rollover not yet implemented.")
-
         # Perform S3 upload after sigterm check — uploads cannot be rolled back.
         sigterm_check()
         for new_path in new_paths:

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -42,7 +42,7 @@ _SCHEMA_URL = os.getenv("MASABI_DATA_SCHEMA_URL", "")
 
 # Maximum update size: Adjust to match the maximum size that can be safely handled
 # by the ECS environment's RAM and disk resources.
-MAXIMUM_ROWS_PER_RUN = 10001
+MAXIMUM_ROWS_PER_RUN = 100001
 
 # Retry config for individual API page requests.
 # On a non-200 response or network error, the request is retried up to
@@ -55,7 +55,7 @@ API_MIN_REQUEST_INTERVAL_S: float = 1.0
 
 # Rescheduling time intervals
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
-NEXT_RUN_IMMEDIATE = 1  # 1 minute  ### TESTING
+NEXT_RUN_IMMEDIATE = 60  # 1 minute
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
 # Exclusive lower bound for the initial historical backfill: 2020-01-01 00:00:00 UTC (ms).
@@ -725,9 +725,6 @@ class ArchiveMasabi(OdinJob):
             source=ds_from_path(sync_paths),
             export_folder=local_dir,
             export_file_prefix="table",
-            mb_per_file=0,  # For testing only!
-            mb_per_group_disk=1,
-            mb_per_group_mem=1
         )
 
         # Perform S3 upload after sigterm check — uploads cannot be rolled back.

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -42,7 +42,7 @@ _SCHEMA_URL = os.getenv("MASABI_DATA_SCHEMA_URL", "")
 
 # Maximum update size: Adjust to match the maximum size that can be safely handled
 # by the ECS environment's RAM and disk resources.
-MAXIMUM_ROWS_PER_RUN = 100001
+MAXIMUM_ROWS_PER_RUN = 101
 
 # Retry config for individual API page requests.
 # On a non-200 response or network error, the request is retried up to
@@ -55,7 +55,7 @@ API_MIN_REQUEST_INTERVAL_S: float = 1.0
 
 # Rescheduling time intervals
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
-NEXT_RUN_IMMEDIATE = 60  # 1 minute
+NEXT_RUN_IMMEDIATE = 1  # 1 minute  ## TESTING
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
 # Exclusive lower bound for the initial historical backfill: 2020-01-01 00:00:00 UTC (ms).
@@ -715,6 +715,7 @@ class ArchiveMasabi(OdinJob):
             sync_paths.append(local_last)
         else:
             local_dir = self.export_folder.replace("s3://", "")
+            os.makedirs(local_dir)
         sync_paths.append(pq_path)
 
         new_row_count = ds_from_path(pq_path).count_rows()
@@ -722,8 +723,9 @@ class ArchiveMasabi(OdinJob):
 
         new_paths = pq_dataset_writer(
             source=ds_from_path(sync_paths),
-            export_folder=local_dir, self.export_folder),
+            export_folder=local_dir,
             export_file_prefix="table",
+            mb_per_file=1,  # For testing only!
         )
 
         # Perform S3 upload after sigterm check — uploads cannot be rolled back.

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -711,7 +711,10 @@ class ArchiveMasabi(OdinJob):
             local_last = os.path.join(self.tmpdir, last_s3.replace("/table_", "/temp_"))
             download_object(found_objs[-1].path, local_last)
             self.schema_check.check_parquet_schema(local_last)
+            local_dir = os.path.dirname(local_last)
             sync_paths.append(local_last)
+        else:
+            local_dir = self.export_folder.replace("s3://", "")
         sync_paths.append(pq_path)
 
         new_row_count = ds_from_path(pq_path).count_rows()
@@ -719,7 +722,7 @@ class ArchiveMasabi(OdinJob):
 
         new_paths = pq_dataset_writer(
             source=ds_from_path(sync_paths),
-            export_folder=os.path.join(self.tmpdir, self.export_folder),
+            export_folder=local_dir, self.export_folder),
             export_file_prefix="table",
         )
 


### PR DESCRIPTION
The old `pq_dataset_writer` function used for generating synced parquet files has an `export_folder` argument; this argument is undocumented, but it turns out that in addition to being the directory to which `pq_dataset_writer` writes its output, `pq_dataset_writer` must also contain the downloaded parquet files. This is because it will look in that directory to determine the correct filename to write (e.g., `table_002.parquet` if the highest-index table downloaded is `table_002.parquet`, etc.) If the provided `export_directory` is empty, it will silently default to `table_001.parquet`; if `export_directory` does not exist, it will **silently create that directory** and then read it, seeing no files, and likewise default to table_001.parquet.

When a table had previously collected enough data that it was split between two files, e.g. `table_001.parquet` and `table_002.parquet`, the pipeline would download `table_002.parquet`, append new data to it, and then, if it sees an empty `export_folder`, write out the result into a new table_001.parquet. This is then uploaded, overwriting table_001.parquet with data from table_002.parquet and later. All subsequent updates will follow the same behavior, overwriting table_001.parquet with table_002.parquet, plus the most recently downloaded data.

For non-Masabi uses, there are different path constructions for the parquet local download target and for `export_folder`, but these wind up being the same in each case. The difference in Masabi's case was due to the addition of the `s3_folder` function to the `ArchiveMasabi.export_folder`, which we started using after the earlier Cubic bug which was due to inconsistent S3 path handling; this added the "s3://" prefix to the path, changing the path provided to `export_folder` and triggering the behavior described above.

As a minimal fix, this PR changes the Masabi pipeline so that the directory sent to `export_folder` is guaranteed to contain the downloaded parquet file, unless there is no pre-existing data.

(This PR includes some changes for validating the parquet rollover behavior which will be removed prior to merging.)