### PR TITLE
Add masabi temporary schema

### DIFF
--- a/src/odin/generate/data_dictionary/duck_db.py
+++ b/src/odin/generate/data_dictionary/duck_db.py
@@ -16,6 +16,7 @@ from odin.utils.locations import AFC_RESTRICTED
 from odin.utils.locations import CUBIC_ODS_REPORTS
 from odin.utils.locations import MASABI_DATA
 from odin.utils.locations import MASABI_RESTRICTED
+from odin.utils.locations import MASABI_TEMP
 from odin.utils.parquet import ds_from_path
 
 
@@ -76,6 +77,13 @@ dataset_views = [
     ViewBuilder(
         s3_prefix=os.path.join(DATA_SPRINGBOARD, MASABI_RESTRICTED),
         schema="masabi_restricted",
+        template=Template(
+            f"{DROP_VIEW} CREATE VIEW $schema.$table AS SELECT $columns FROM {READ_PQ};"
+        ),
+    ),
+    ViewBuilder(
+        s3_prefix=os.path.join(DATA_SPRINGBOARD, MASABI_TEMP),
+        schema="masabi_temporary",
         template=Template(
             f"{DROP_VIEW} CREATE VIEW $schema.$table AS SELECT $columns FROM {READ_PQ};"
         ),

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -59,7 +59,7 @@ NEXT_RUN_IMMEDIATE = 60  # 1 minute
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
 # Exclusive lower bound for the initial historical backfill: 2025-06-01 00:00:00 UTC (ms).
-MASABI_START_TIMESTAMP_MS: int = 1_748_736_000_000
+MASABI_START_TIMESTAMP_MS: int = 1_577_836_800_000
 
 _YAML_TYPE_MAP: dict[str, pl.DataType] = {
     "string": pl.String(),

--- a/src/odin/utils/locations.py
+++ b/src/odin/utils/locations.py
@@ -31,3 +31,4 @@ AFC_RESTRICTED = f"{ODIN_DATA}/sb/restricted"
 # Masabi
 MASABI_DATA = f"{ODIN_DATA}/masabi/api"
 MASABI_RESTRICTED = f"{ODIN_DATA}/masabi/restricted"
+MASABI_TEMP = f"{ODIN_DATA}/masabi/temporary"


### PR DESCRIPTION
While we're recovering the lost Masabi data, we want to have the most recent year's data available; this will be provided in a temporary schema ("masabi_temporary") while the main schema catches up. This PR adds that schema, copies the current Masabi data into it, and re-sets the ingestion start date for the full catch-up. 