### PR TITLE
chore: adding new migrations (and s3 copy helper function)

### DIFF
--- a/src/odin/migrate/migrations/odin-alpha-dev/0001.py
+++ b/src/odin/migrate/migrations/odin-alpha-dev/0001.py
@@ -25,9 +25,7 @@ def migration() -> None:
     )
 
     source_objects = [obj.path for obj in list_objects(source_prefix)]
-    copy_jobs = [
-        (obj, obj.replace(source_prefix, destination_prefix, 1)) for obj in source_objects
-    ]
+    copy_jobs = [(obj, obj.replace(source_prefix, destination_prefix, 1)) for obj in source_objects]
     failures = copy_objects(copy_jobs)
 
     log.add_metadata(

--- a/src/odin/migrate/migrations/odin-alpha-dev/0001.py
+++ b/src/odin/migrate/migrations/odin-alpha-dev/0001.py
@@ -1,0 +1,44 @@
+import os
+
+from odin.utils.aws.s3 import copy_objects
+from odin.utils.aws.s3 import list_objects
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.locations import MASABI_DATA
+from odin.utils.locations import MASABI_TEMP
+from odin.utils.logger import ProcessLog
+
+
+def migration() -> None:
+    """
+    Copy Masabi public-table data into the temporary prefix.
+
+    This preserves the existing object layout while duplicating the current
+    MASABI public-data snapshot under the temporary path.
+    """
+    source_prefix = os.path.join(DATA_SPRINGBOARD, MASABI_DATA, "")
+    destination_prefix = os.path.join(DATA_SPRINGBOARD, MASABI_TEMP, "")
+    log = ProcessLog(
+        "odin_migration",
+        migration="alpha_dev_0001",
+        source_prefix=source_prefix,
+        destination_prefix=destination_prefix,
+    )
+
+    source_objects = [obj.path for obj in list_objects(source_prefix)]
+    copy_jobs = [
+        (obj, obj.replace(source_prefix, destination_prefix, 1)) for obj in source_objects
+    ]
+    failures = copy_objects(copy_jobs)
+
+    log.add_metadata(
+        objects_attempted=len(copy_jobs),
+        objects_failed=len(failures),
+        failure_details=str(failures) if failures else "none",
+    )
+
+    if failures:
+        exception = AssertionError(f"Failed to copy objects for source prefix: {source_prefix}")
+        log.failed(exception)
+        raise exception
+
+    log.complete()

--- a/src/odin/migrate/migrations/odin-alpha-prod/0001.py
+++ b/src/odin/migrate/migrations/odin-alpha-prod/0001.py
@@ -25,9 +25,7 @@ def migration() -> None:
     )
 
     source_objects = [obj.path for obj in list_objects(source_prefix)]
-    copy_jobs = [
-        (obj, obj.replace(source_prefix, destination_prefix, 1)) for obj in source_objects
-    ]
+    copy_jobs = [(obj, obj.replace(source_prefix, destination_prefix, 1)) for obj in source_objects]
     failures = copy_objects(copy_jobs)
 
     log.add_metadata(

--- a/src/odin/migrate/migrations/odin-alpha-prod/0001.py
+++ b/src/odin/migrate/migrations/odin-alpha-prod/0001.py
@@ -1,0 +1,44 @@
+import os
+
+from odin.utils.aws.s3 import copy_objects
+from odin.utils.aws.s3 import list_objects
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.locations import MASABI_DATA
+from odin.utils.locations import MASABI_TEMP
+from odin.utils.logger import ProcessLog
+
+
+def migration() -> None:
+    """
+    Copy Masabi public-table data into the temporary prefix.
+
+    This preserves the existing object layout while duplicating the current
+    MASABI public-data snapshot under the temporary path.
+    """
+    source_prefix = os.path.join(DATA_SPRINGBOARD, MASABI_DATA, "")
+    destination_prefix = os.path.join(DATA_SPRINGBOARD, MASABI_TEMP, "")
+    log = ProcessLog(
+        "odin_migration",
+        migration="alpha_prod_0001",
+        source_prefix=source_prefix,
+        destination_prefix=destination_prefix,
+    )
+
+    source_objects = [obj.path for obj in list_objects(source_prefix)]
+    copy_jobs = [
+        (obj, obj.replace(source_prefix, destination_prefix, 1)) for obj in source_objects
+    ]
+    failures = copy_objects(copy_jobs)
+
+    log.add_metadata(
+        objects_attempted=len(copy_jobs),
+        objects_failed=len(failures),
+        failure_details=str(failures) if failures else "none",
+    )
+
+    if failures:
+        exception = AssertionError(f"Failed to copy objects for source prefix: {source_prefix}")
+        log.failed(exception)
+        raise exception
+
+    log.complete()

--- a/src/odin/utils/aws/s3.py
+++ b/src/odin/utils/aws/s3.py
@@ -336,6 +336,65 @@ def delete_objects(objects: List[str]):
     return failed_delete
 
 
+def copy_object(from_object: str, to_object: str) -> str | None:
+    """
+    Copy an S3 object.
+
+    :param from_object: COPY from as 's3://bucket/object' or 'bucket/object'
+    :param to_object: COPY to as 's3://bucket/object' or 'bucket/object'
+
+    :return: 'from_object' if failed, else None
+    """
+    logger = ProcessLog("copy_object", from_object=from_object, to_object=to_object)
+    try:
+        client = get_client()
+        copy_source = os.path.join(*split_object(from_object))
+        to_bucket, to_key = split_object(to_object)
+
+        client.copy_object(
+            Bucket=to_bucket,
+            CopySource=copy_source,
+            Key=to_key,
+        )
+
+        logger.complete()
+        return None
+
+    except Exception as exception:
+        logger.failed(exception)
+
+    return from_object
+
+
+def copy_objects(copy_tuples: list[tuple[str, str]]) -> list[str]:
+    """
+    Copy a list of S3 objects sequentially.
+
+    :param copy_tuples: list of tuples[from_object, to_object]
+
+    :return: list of objects that failed to copy
+    """
+    if len(copy_tuples) == 0:
+        return []
+
+    logger = ProcessLog("copy_objects", object_count=len(copy_tuples))
+    failed_copy = []
+
+    for from_object, to_object in copy_tuples:
+        result = copy_object(from_object, to_object)
+        if isinstance(result, str):
+            failed_copy.append(result)
+
+    logger.add_metadata(failed_count=len(failed_copy))
+    if len(failed_copy) == 0:
+        logger.complete()
+    else:
+        exception = FileExistsError(f"Failed to copy S3 objects: ({','.join(failed_copy)})")
+        logger.failed(exception=exception)
+
+    return failed_copy
+
+
 def rename_object(from_object: str, to_object: str) -> str | None:
     """
     Rename an S3 object as copy and delete operation.


### PR DESCRIPTION
This starts our convoluted recovery scheme for Masabi data with minimal disruption for analysts:
- [x] run this migration, to copy 1-year data over to a new `MASABI_TEMP` location in case the new fix doesn't work as intended
- [x] apply the fix in https://github.com/mbta/odin/pull/175
- [x] wait to verify behavior
- [ ] run another move migration to copy completed 1-year data over to copy over to `MASABI_TEMP` 
- [ ] put in the schema change PR (https://github.com/mbta/odin/pull/176; beta instance will be saturated, but [duck_db.py](https://github.com/mbta/odin/pull/176/changes#diff-c9391f8e2f8f8ddc40653e3abff00cd0fec2b4c6425b26c12b6ab8af32ac46f8) will run at some point because it is running on alpha)
- [ ] Put in a new delete migration to delete 1-year data in `MASABI_DATA` and kick off ingestion of 5 year data