### PR TITLE
feat: enabling high-frequency tables

### DIFF
--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -23,6 +23,7 @@ from odin.utils.aws.s3 import download_object
 from odin.utils.aws.s3 import upload_file
 from odin.utils.aws.s3 import delete_objects
 from odin.ingestion.afc.afc_tables import API_TABLES_INSTANCE
+from odin.ingestion.afc.afc_tables import _ODIN_INSTANCE
 from odin.utils.parquet import ds_metadata_min_max
 from odin.utils.parquet import ds_from_path
 from odin.utils.parquet import pq_dataset_writer
@@ -38,6 +39,7 @@ class APIEmptyResponseError(Exception):
 
 
 NEXT_RUN_DEFAULT = 60 * 60 * 6  # 6 hours
+NEXT_RUN_BETA = 60 * 60  # 1 hour
 
 API_ROOT = os.getenv("AFC_ROOT", "")
 
@@ -480,7 +482,7 @@ class ArchiveAFCAPI(OdinJob):
         If `count` returning more than 1 job, based on self.max_job_id, more jobs available.
         """
         log = ProcessLog("re_run_check", table=self.table, max_job_id=self.max_job_id)
-        return_duration = NEXT_RUN_DEFAULT
+        return_duration = NEXT_RUN_BETA if _ODIN_INSTANCE == "beta" else NEXT_RUN_DEFAULT
         if self.max_job_id > 0:
             r = self.make_request(
                 url=f"{API_ROOT}/count",

--- a/src/odin/ingestion/afc/afc_tables.py
+++ b/src/odin/ingestion/afc/afc_tables.py
@@ -7,15 +7,12 @@ API_TABLES_ALPHA = [
     "v_ca_legal_relations",
     "v_deviceclass",
     "v_eventgroup",
-    "v_eventhistory",
     "v_eventtext",
     "v_legal_persons",
-    "v_mainshift",
     "v_medium_types",
     "v_person",
     "v_product_templates",
     "v_routes",
-    "v_sales_txns",
     "v_shiftevent",
     "v_stop_points",
     "v_ta_ca_relations",
@@ -23,7 +20,6 @@ API_TABLES_ALPHA = [
     "v_trips",
     "v_tvmstation",
     "v_tvmtable",
-    "v_validation_taps",
     "v_cashless_payments",
     "v_inspections",
     "v_tsmstatus",
@@ -39,17 +35,22 @@ API_TABLES_ALPHA = [
     "v_moneycontainersum",
     "v_moneycontainercontentsum",
     "v_accesslevel",
-    "v_svw_balance_changes",
     "v_transit_accounts",
     "v_payment_methods",
     "v_entitlements",
     "v_entitlements_full",  # temporary full snapshot export containing older data
     "v_payment_method_instances",
-    "v_products",
     "v_versions",
 ]
 
-API_TABLES_BETA: list[str] = []
+API_TABLES_BETA: list[str] = [
+    "v_validation_taps",
+    "v_sales_txns",
+    "v_products",
+    "v_svw_balance_changes",
+    "v_eventhistory",
+    "v_mainshift",
+]
 
 API_TABLES = API_TABLES_ALPHA + API_TABLES_BETA
 

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -17,6 +17,7 @@ from odin.utils.aws.s3 import s3_folder
 from odin.utils.aws.s3 import download_object
 from odin.utils.aws.s3 import list_objects
 from odin.utils.aws.s3 import upload_file
+from odin.ingestion.masabi.masabi_tables import _ODIN_INSTANCE
 from odin.ingestion.masabi.masabi_tables import TABLES_INSTANCE
 from odin.utils.parquet import ds_from_path
 from odin.utils.parquet import ds_metadata_min_max
@@ -55,6 +56,7 @@ API_MIN_REQUEST_INTERVAL_S: float = 1.0
 
 # Rescheduling time intervals
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
+NEXT_RUN_BETA = 60 * 60  # 1 hour
 NEXT_RUN_IMMEDIATE = 60  # 1 minute
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
@@ -791,7 +793,7 @@ class ArchiveMasabi(OdinJob):
             return NEXT_RUN_IMMEDIATE
         else:
             log.complete(next_run_interval="normal")
-            return NEXT_RUN_DEFAULT
+            return NEXT_RUN_BETA if _ODIN_INSTANCE == "beta" else NEXT_RUN_DEFAULT
 
 
 def schedule_masabi_archive(schedule: sched.scheduler) -> None:

--- a/src/odin/ingestion/masabi/masabi_tables.py
+++ b/src/odin/ingestion/masabi/masabi_tables.py
@@ -8,14 +8,14 @@ TABLES_ALPHA = [
     # "view.hub_search_guest_account",
     # "view.hub_search_vendor_sale",
     # "view.validators",
+    "retail.account_actions",
+    "retail.activations",
+    "retail.tickets",
+    "validation.scans",
 ]
 
 TABLES_BETA: list[str] = [
-    "retail.account_actions",
-    "retail.activations",
     "retail.ticket_purchases",
-    "retail.tickets",
-    "validation.scans",
 ]
 
 TABLES = TABLES_ALPHA + TABLES_BETA

--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -78,8 +78,6 @@ def start():
     if odin_instance in ["alpha"]:
         schedule_restricted_afc_archive(schedule)
         # schedule_tableau_upload(schedule)
-
-    if odin_instance in ["beta"]:
         schedule_dictionary(schedule)
 
     schedule.run()


### PR DESCRIPTION
This PR does 3 things:
1. Sets a shorter default duration (1 hour) for next run for AFC and Masabi API jobs when running on beta
2. Moves all high frequency AFC and Masabi API jobs to beta
3. Moves `schedule_dictionary()` (which includes expensive view materializations) back to alpha, to free up resources

Asana: [Increase frequency for Cubic, S&B, and Masabi tables to support FIFA reporting](https://app.asana.com/1/15492006741476/project/1208949713596462/task/1215303756606319?focus=true)