### PR TITLE
fix: workload tuning additions for mat view performance

### DIFF
--- a/src/odin/generate/data_dictionary/duck_db.py
+++ b/src/odin/generate/data_dictionary/duck_db.py
@@ -98,6 +98,7 @@ def create_fares_db(folder: str) -> str:
 
         con.execute(f"set temp_directory = '{os.path.join(folder, 'duckdb_spill')}'")
         con.execute("set memory_limit='15GB'")
+        con.execute("set threads='2'")
 
         for view in dataset_views:
             con.execute(f"CREATE SCHEMA IF NOT EXISTS {view.schema};")

--- a/src/odin/generate/data_dictionary/duck_db.py
+++ b/src/odin/generate/data_dictionary/duck_db.py
@@ -96,6 +96,9 @@ def create_fares_db(folder: str) -> str:
         # Hopefully this works on ECS...
         con.execute("CREATE OR REPLACE SECRET secret (TYPE s3, PROVIDER credential_chain);")
 
+        con.execute(f"set temp_directory = '{os.path.join(folder, 'duckdb_spill')}'")
+        con.execute("set memory_limit='15GB'")
+
         for view in dataset_views:
             con.execute(f"CREATE SCHEMA IF NOT EXISTS {view.schema};")
             for view_table in list_partitions(view.s3_prefix):
@@ -134,9 +137,11 @@ def create_fares_db(folder: str) -> str:
                 view_query = f"CREATE VIEW cubic_reports.{view_name} AS SELECT * FROM read_parquet('s3://{upload_path}')"
                 con.execute(view_query)
 
+                os.remove(mat_view_path)
+
+                view_log.complete()
             except Exception as exception:
                 view_log.failed(exception=exception)
-            view_log.complete()
         for view_file in files("odin.generate.data_dictionary.sql.views").iterdir():
             if not view_file.name.endswith(".sql"):
                 continue


### PR DESCRIPTION
Trying to materialize the COMP B views currently fails:

```
7959f6122a6 ERROR uuid=3e99cd25-92e2-4cbf-a101-e7f43da2247d, File "/usr/local/lib/python3.13/site-packages/odin/generate/data_dictionary/duck_db.py", line 129, in create_fares_db
87959f6122a6 ERROR uuid=3e99cd25-92e2-4cbf-a101-e7f43da2247d, con.execute(mat_view_query)
87959f6122a6 ERROR uuid=3e99cd25-92e2-4cbf-a101-e7f43da2247d, ~~~~~~~~~~~^^^^^^^^^^^^^^^^
87959f6122a6 ERROR uuid=3e99cd25-92e2-4cbf-a101-e7f43da2247d, _duckdb.OutOfMemoryException: Out of Memory Error: could not allocate block of size 256.0 KiB (12.7 GiB/12.7 GiB used)
87959f6122a6 Possible solutions:
87959f6122a6 * Reducing the number of threads (SET threads=X)
87959f6122a6 * Disabling insertion-order preservation (SET preserve_insertion_order=false)
87959f6122a6 * Increasing the memory limit (SET memory_limit='...GB')
87959f6122a6 See also https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads
87959f6122a6 INFO uuid=3e99cd25-92e2-4cbf-a101-e7f43da2247d, parent=odin, process=create_report_mat_views, odin_instance=beta, ecs_task_group=family:odin-beta-prod, process_id=375, status=failed, disk_free_mb=95682, sys_mem_free_pct=85, proc_mem_used_mb=10253, duration=418.02, error_type=OutOfMemoryException, view_name=mat_comp_b_txn_a
```

This PR adds several of the workload tuning measures noted in the link; hopefully this will get the view materialization through.

NB: Limiting the thread count may slow down everything else that duck_db.py does; we can re-evaluate if the view materialization works and we keep it around.