### PR TITLE
chore: increasing beta table update frequency

### DIFF
--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -40,7 +40,7 @@ from odin.ingestion.qlik.tables import _ODIN_INSTANCE
 from odin.ingestion.qlik.tables import CUBIC_ODS_TABLES_INSTANCE
 
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
-NEXT_RUN_BETA = 60 * 60  # 1 hour
+NEXT_RUN_BETA = 60 * 15  # 15 minutes
 NEXT_RUN_IMMEDIATE = 60 * 5  # 5 minutes
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 MAX_LOAD_RECORDS = 10_000

--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -39,7 +39,7 @@ class APIEmptyResponseError(Exception):
 
 
 NEXT_RUN_DEFAULT = 60 * 60 * 6  # 6 hours
-NEXT_RUN_BETA = 60 * 60  # 1 hour
+NEXT_RUN_BETA = 60 * 15  # 15 minutes
 
 API_ROOT = os.getenv("AFC_ROOT", "")
 

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -56,7 +56,7 @@ API_MIN_REQUEST_INTERVAL_S: float = 1.0
 
 # Rescheduling time intervals
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
-NEXT_RUN_BETA = 60 * 60  # 1 hour
+NEXT_RUN_BETA = 60 * 15  # 15 minutes
 NEXT_RUN_IMMEDIATE = 60  # 1 minute
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 

--- a/src/odin/ingestion/qlik/cubic_archive.py
+++ b/src/odin/ingestion/qlik/cubic_archive.py
@@ -48,7 +48,7 @@ from odin.utils.parquet import ds_from_path
 from odin.utils.parquet import ds_unique_values
 
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
-NEXT_RUN_BETA = 60 * 60  # 1 hour
+NEXT_RUN_BETA = 60 * 15  # 15 minutes
 NEXT_RUN_IMMEDIATE = 60 * 5  # 5 minutes
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 


### PR DESCRIPTION
Based on my back of the napkin math, we should be able to pretty comfortably increase our update frequency to 4x/hour. The risk of this causing data to fall behind (due to e.g. fixed overhead from each call taking up too much time in the schedule) is very low