### PR TITLE
Add retail.activations to Odin-beta list for fast updates

### DIFF
--- a/src/odin/ingestion/masabi/masabi_tables.py
+++ b/src/odin/ingestion/masabi/masabi_tables.py
@@ -9,13 +9,13 @@ TABLES_ALPHA = [
     # "view.hub_search_vendor_sale",
     # "view.validators",
     "retail.account_actions",
-    "retail.activations",
     "retail.tickets",
     "validation.scans",
 ]
 
 TABLES_BETA: list[str] = [
     "retail.ticket_purchases",
+    "retail.activations",
 ]
 
 TABLES = TABLES_ALPHA + TABLES_BETA


### PR DESCRIPTION
Asana: https://app.asana.com/1/15492006741476/project/1213716198445326/task/1215781460125018?focus=true

Rebecca Cohen requested that the Masabi retail.activations be added to the FIFA rapid-update schedule. This moves the table to the Odin-beta list. All table update cadences are set by Odin instance, so this will cause it to be updated on the rapid schedule.