### PR TITLE
Fix S3 path handling bug in AFC update code

### DIFF
--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -18,6 +18,7 @@ from odin.utils.runtime import disk_free_pct
 from odin.utils.logger import ProcessLog
 from odin.utils.locations import AFC_DATA
 from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.aws.s3 import s3_folder
 from odin.utils.aws.s3 import list_objects
 from odin.utils.aws.s3 import download_object
 from odin.utils.aws.s3 import upload_file
@@ -262,7 +263,7 @@ class ArchiveAFCAPI(OdinJob):
 
         # set self.pq_job_id from parquet dataset or specified start point
         last_exported_id = 0
-        if list_objects(self.export_folder, in_filter=".parquet"):
+        if list_objects(s3_folder(self.export_folder), in_filter=".parquet"):
             _, last_exported_id = ds_metadata_min_max(
                 ds_from_path(f"s3://{self.export_folder}"), "job_id"
             )
@@ -443,7 +444,7 @@ class ArchiveAFCAPI(OdinJob):
         if len(sync_paths) == 0:
             return
 
-        found_objs = list_objects(f"s3://{self.export_folder}", in_filter=".parquet")
+        found_objs = list_objects(s3_folder(self.export_folder), in_filter=".parquet")
         del_objs = []
         if self.table_type == "transactional":
             # `transactional` table type is supposed to be incremental (append-only) data model

--- a/src/odin/ingestion/afc/afc_restricted.py
+++ b/src/odin/ingestion/afc/afc_restricted.py
@@ -8,6 +8,7 @@ from odin.utils.runtime import sigterm_check
 from odin.utils.logger import ProcessLog
 from odin.utils.locations import DATA_SPRINGBOARD
 from odin.utils.locations import AFC_RESTRICTED
+from odin.utils.aws.s3 import s3_folder
 from odin.utils.aws.s3 import list_objects
 from odin.utils.aws.s3 import download_object
 from odin.utils.aws.s3 import upload_file
@@ -68,7 +69,7 @@ class RestrictedAFC(ArchiveAFCAPI):
         )
         new_paths: list[str] = []
         for exp_fldr, read_paths in export_jobs:
-            found_objs = list_objects(f"s3://{exp_fldr}", in_filter=".parquet")
+            found_objs = list_objects(s3_folder(exp_fldr), in_filter=".parquet")
             if found_objs:
                 sync_file = found_objs[-1].path.replace("s3://", "")
                 s3_pq_file = os.path.join(self.tmpdir, sync_file.replace("/table_", "/temp_"))

--- a/tests/ingestion/afc/afc_archive_test.py
+++ b/tests/ingestion/afc/afc_archive_test.py
@@ -351,6 +351,44 @@ def test_sync_parquet_transactional(
 @patch("odin.ingestion.afc.afc_archive.delete_objects")
 @patch("odin.ingestion.afc.afc_archive.upload_file")
 @patch("odin.ingestion.afc.afc_archive.download_object")
+def test_sync_parquet_lists_folder_scoped_prefix(
+    dl_obj: MagicMock, mock_upload: MagicMock, del_obj: MagicMock, ls_obj: MagicMock, tmpdir
+):
+    """
+    sync_parquet must scope its S3 listing to the table's own folder.
+
+    A bare prefix (no trailing "/") matches sibling folders whose name starts with
+    this table's name (e.g. "v_entitlements" also matches "v_entitlements_full/..."),
+    which makes found_objs[-1] resolve to the wrong table's file and corrupts the
+    re-merge/part-offset, silently overwriting data on S3. Pin the folder boundary.
+    """
+    export = "bucket/odin/data/sb/api/v_entitlements"
+    data = [{"job_id": 1, "value": "sid_1"}]
+    pl.DataFrame(data).write_ndjson(os.path.join(tmpdir, "1.json"))
+
+    job = ArchiveAFCAPI("test_table")
+    job.tmpdir = tmpdir
+    job.schema = pl.Schema({"job_id": pl.Int64(), "value": pl.String()})
+    job.table_type = "transactional"
+    job.ts_cols = []
+    job.export_folder = export
+    ls_obj.return_value = []
+
+    job.sync_parquet()
+
+    # Every S3 listing for this folder must end with "/" so a raw prefix match cannot
+    # spill into a sibling folder like ".../v_entitlements_full/".
+    assert ls_obj.call_count >= 1
+    for c in ls_obj.call_args_list:
+        listed_prefix = c.args[0]
+        assert listed_prefix.endswith("/"), f"listing not folder-scoped: {listed_prefix!r}"
+        assert listed_prefix.rstrip("/").endswith("/v_entitlements")
+
+
+@patch("odin.ingestion.afc.afc_archive.list_objects")
+@patch("odin.ingestion.afc.afc_archive.delete_objects")
+@patch("odin.ingestion.afc.afc_archive.upload_file")
+@patch("odin.ingestion.afc.afc_archive.download_object")
 @patch.dict(
     "odin.ingestion.afc.afc_archive.API_TABLE_PII_DROP_COLUMNS", {"test_table": ["pii_value"]}
 )


### PR DESCRIPTION
Asana (at least mostly related): https://app.asana.com/1/15492006741476/project/1213716198445326/task/1215684729287628?focus=true

It turned out that v_entitlements was consistently missing all data except for the most recent update. This was due to improper S3 path handling in the old list_objects() utility function leading to a collision with v_entitlements_full, loading in the wrong file, and incorrect syncing left only the new data being uploaded (which simultaneously overwrote the old, complete v_entitlements parquet.)

This fix is intentionally minimal to avoid running into other issues with the parquet utility code. (E.g., the naive fix, changing the definition of AFCArchive.export_folder to use s3_folder directly, would have caused the same issue that deleted five years' worth of Masabi data last week.)