### PR TITLE
fix(regression tests): only check min_job_id if table is transactional; check size less strictly

### DIFF
--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -301,7 +301,8 @@ class ArchiveAFCAPI(OdinJob):
             )
 
         if (
-            pre_snapshot["min_job_id"] is not None
+            self.table_type == "transactional"
+            and pre_snapshot["min_job_id"] is not None
             and post_snapshot["min_job_id"] is not None
             and post_snapshot["min_job_id"] > pre_snapshot["min_job_id"]
         ):
@@ -320,7 +321,7 @@ class ArchiveAFCAPI(OdinJob):
                 )
             )
 
-        if post_snapshot["total_size_bytes"] < pre_snapshot["total_size_bytes"]:
+        if post_snapshot["total_size_bytes"] < pre_snapshot["total_size_bytes"] * 0.99:
             regressions.append(
                 (
                     "parquet total bytes decreased after write: "


### PR DESCRIPTION
Follow-on to https://github.com/mbta/odin/pull/191, updating two regressions which are causing false positives:
- `min_job_id` seems to increase each time in static tables by design, so an increase in `min_job_id` is now only a regression for transactional tables
- `total_size_bytes` can decrease slightly when data is added to the parquet file, presumably due to the compression process. Now only reductions in size greater than 1% of the original file are reported to logs as a regression (which, again, do not block any operations)

Asana: [Add lightweight monitoring for AFC pipeline](https://app.asana.com/1/15492006741476/project/1208949713596457/task/1215865675975562?focus=true)