### PR TITLE
chore: regenerating S&B tables

### DIFF
--- a/src/odin/migrate/migrations/odin-alpha-dev/0002.py
+++ b/src/odin/migrate/migrations/odin-alpha-dev/0002.py
@@ -1,0 +1,39 @@
+import os
+
+from odin.utils.aws.s3 import list_objects
+from odin.utils.aws.s3 import delete_objects
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.locations import AFC_DATA
+from odin.utils.logger import ProcessLog
+
+TABLES_TO_DELETE: list[str] = [
+    "v_cashboxmovement",
+    "v_cashboxmovementmoneydetails",
+    "v_entitlements",
+    "v_entitlements_full",
+]
+
+
+def migration() -> None:
+    """
+    Delete all files under
+    s3://<springboard>/odin/data/afc/<table>/
+    for each table in TABLES_TO_DELETE.
+    """
+    log = ProcessLog("odin_migration", migration="alpha_dev_0002")
+    failures: dict[str, int] = {}
+
+    for table in TABLES_TO_DELETE:
+        prefix = os.path.join(DATA_SPRINGBOARD, AFC_DATA, table, "")
+        remaining = delete_objects([obj.path for obj in list_objects(prefix)])
+        if remaining:
+            failures[prefix] = len(remaining)
+
+    log.add_metadata(
+        tables_attempted=len(TABLES_TO_DELETE),
+        tables_failed=len(failures),
+        failure_details=str(failures) if failures else "none",
+    )
+    log.complete()
+
+    assert not failures, f"Failed to delete objects for prefixes: {failures}"

--- a/src/odin/migrate/migrations/odin-alpha-prod/0002.py
+++ b/src/odin/migrate/migrations/odin-alpha-prod/0002.py
@@ -1,0 +1,39 @@
+import os
+
+from odin.utils.aws.s3 import list_objects
+from odin.utils.aws.s3 import delete_objects
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.locations import AFC_DATA
+from odin.utils.logger import ProcessLog
+
+TABLES_TO_DELETE: list[str] = [
+    "v_cashboxmovement",
+    "v_cashboxmovementmoneydetails",
+    "v_entitlements",
+    "v_entitlements_full",
+]
+
+
+def migration() -> None:
+    """
+    Delete all files under
+    s3://<springboard>/odin/data/afc/<table>/
+    for each table in TABLES_TO_DELETE.
+    """
+    log = ProcessLog("odin_migration", migration="alpha_prod_0002")
+    failures: dict[str, int] = {}
+
+    for table in TABLES_TO_DELETE:
+        prefix = os.path.join(DATA_SPRINGBOARD, AFC_DATA, table, "")
+        remaining = delete_objects([obj.path for obj in list_objects(prefix)])
+        if remaining:
+            failures[prefix] = len(remaining)
+
+    log.add_metadata(
+        tables_attempted=len(TABLES_TO_DELETE),
+        tables_failed=len(failures),
+        failure_details=str(failures) if failures else "none",
+    )
+    log.complete()
+
+    assert not failures, f"Failed to delete objects for prefixes: {failures}"


### PR DESCRIPTION
Following https://github.com/mbta/odin/pull/190 (and the logging introduced in https://github.com/mbta/odin/pull/191, https://github.com/mbta/odin/pull/192), the affected tables (i.e., any tables which have full table names as common prefixes) should be regenerated

[Asana](https://app.asana.com/1/15492006741476/project/1213716198445326/task/1215684729287628?focus=true)