### PR TITLE
fix(regression tests): even less strict post_snapshot size check

### DIFF
--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -321,7 +321,7 @@ class ArchiveAFCAPI(OdinJob):
                 )
             )
 
-        if post_snapshot["total_size_bytes"] < pre_snapshot["total_size_bytes"] * 0.99:
+        if post_snapshot["total_size_bytes"] < pre_snapshot["total_size_bytes"] * 0.75:
             regressions.append(
                 (
                     "parquet total bytes decreased after write: "


### PR DESCRIPTION
https://github.com/mbta/odin/pull/192 didn't go far enough, as there is still some clutter in the regression logs. This should do it