### PR TITLE
feat: Add OdinJob memory watch loop and log output.

### DIFF
--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from abc import abstractmethod
 from multiprocessing import get_context
+from multiprocessing.process import BaseProcess
 from multiprocessing.sharedctypes import Synchronized
 from typing import Dict
 import glob
@@ -9,6 +10,7 @@ import shutil
 import tempfile
 import sched
 
+import psutil
 
 from odin.utils.logger import ProcessLog
 from odin.utils.logger import MdValues
@@ -16,6 +18,9 @@ from odin.utils.runtime import sigterm_check
 
 NEXT_RUN_DEFAULT = 60 * 60 * 6  # 6 hours
 NEXT_RUN_FAILED = 60 * 60 * 24  # 24 hours
+
+# How often the parent samples a running job subprocess' memory, in seconds
+MEM_POLL_INTERVAL_SECS = 1.0
 
 # Prefix for Odin temp directories to avoid conflicts with other processes
 ODINJOB_TMPDIR_PREFIX = "odinjob_tmp_"
@@ -110,6 +115,51 @@ class OdinJob(ABC):
             return_val.value = run_delay_secs
 
 
+def _proc_tree_rss_mb(proc: psutil.Process) -> float:
+    """Resident set size of ``proc`` and all of its children, in MB."""
+    rss = proc.memory_info().rss
+    for child in proc.children(recursive=True):
+        try:
+            rss += child.memory_info().rss
+        except psutil.NoSuchProcess:
+            # A child proc died mid-sample
+            continue
+    return rss / (1024 * 1024)
+
+
+def _monitor_proc_peak_rss_mb(proc: BaseProcess, poll_interval_secs: float) -> float:
+    """
+    Track the peak resident memory of a running job Process (and its children).
+
+    Sampling is done from the parent so the final reading survives an OOM kill of the
+    child. Blocks until ``proc`` exits, then returns the high-water mark in MB.
+
+    :param proc: the started job subprocess to monitor
+    :param poll_interval_secs: seconds between memory samples
+
+    :return: peak resident memory observed, in MB
+    """
+    peak_mem_mb = 0.0
+    try:
+        mon = psutil.Process(proc.pid)
+    except psutil.NoSuchProcess:
+        # Job finished before we could attach; nothing to sample
+        proc.join()
+        return peak_mem_mb
+
+    while True:
+        try:
+            peak_mem_mb = max(peak_mem_mb, _proc_tree_rss_mb(mon))
+        except psutil.NoSuchProcess:
+            break
+        if not proc.is_alive():
+            break
+        proc.join(timeout=poll_interval_secs)
+
+    proc.join()
+    return peak_mem_mb
+
+
 def job_proc_schedule(job: OdinJob, schedule: sched.scheduler | None) -> None:
     """
     Odin Job Runner as Process.
@@ -134,12 +184,25 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler | None) -> None:
     proc_return_val = return_manager.Value("i", NEXT_RUN_FAILED)
     proc = get_context("spawn").Process(target=job.start, args=(proc_return_val,))
     proc.start()
-    proc.join()
+
+    # Track the job subprocess' peak memory from the parent so OOM-prone jobs can be
+    # identified by name and arguments (e.g. which table's update job is OOMing). This
+    # blocks until the job finishes, replacing a plain proc.join().
+    peak_mem_mb = _monitor_proc_peak_rss_mb(proc, MEM_POLL_INTERVAL_SECS)
+
+    ProcessLog(
+        "odin_job_peak_mem",
+        job_type=job.__class__.__name__,
+        peak_mem_mb=f"{peak_mem_mb:.2f}",
+        **job.start_kwargs,
+    ).complete()
+
     if proc.exitcode != 0:
         fail_log = ProcessLog(
             "odin_job_died",
             job_type=job.__class__.__name__,
             job_exit_code=proc.exitcode,
+            peak_mem_mb=f"{peak_mem_mb:.2f}",
             **job.start_kwargs,
         )
         fail_log.failed(SystemError("OdinJob killed by ECS."))

--- a/tests/job_test.py
+++ b/tests/job_test.py
@@ -4,6 +4,8 @@ import time
 from multiprocessing import get_context
 
 from odin.job import OdinJob
+from odin.job import job_proc_schedule as real_job_proc_schedule
+from odin.job import _monitor_proc_peak_rss_mb
 
 
 # caplog doesn't work in multiprocessing. this should be ok for now, but could be improved
@@ -80,3 +82,45 @@ def test_odin_job(caplog, monkeypatch) -> None:
         job_proc_schedule(test_job, scheduler)
     assert len(caplog.messages) == 1
     assert "process=stopping_ecs" in caplog.messages[0]
+
+
+# Defined at module level so the spawn context can pickle them
+def _mem_hog() -> None:
+    """Allocate ~50MB and hold it briefly so the parent can sample the footprint."""
+    blob = bytearray(50 * 1024 * 1024)  # noqa: F841 -- keep ref so it stays resident
+    time.sleep(0.5)
+
+
+class PeakMemJob(OdinJob):
+    """Trivial job used to exercise peak-memory logging in the real runner."""
+
+    start_kwargs = {"table": "retail.tickets"}
+
+    def run(self) -> int:
+        """Return a fixed re-run delay."""
+        return 1000
+
+
+def test_monitor_proc_peak_rss_mb() -> None:
+    """A running subprocess' peak resident memory is captured from the parent."""
+    proc = get_context("spawn").Process(target=_mem_hog)
+    proc.start()
+    peak_mem_mb = _monitor_proc_peak_rss_mb(proc, 0.05)
+
+    # Process is fully reaped and we observed a non-trivial footprint
+    assert proc.exitcode == 0
+    assert peak_mem_mb > 10.0
+
+
+def test_job_proc_schedule_logs_peak_mem(caplog) -> None:
+    """The real runner logs peak memory with job type and start_kwargs."""
+    scheduler = sched.scheduler(time.monotonic, time.sleep)
+    real_job_proc_schedule(PeakMemJob(), scheduler)
+
+    peak_logs = [m for m in caplog.messages if "process=odin_job_peak_mem" in m]
+    assert len(peak_logs) > 0
+    assert any("job_type=PeakMemJob" in m for m in peak_logs)
+    assert any("table=retail.tickets" in m for m in peak_logs)
+    assert any("peak_mem_mb=" in m for m in peak_logs)
+
+    scheduler.cancel(scheduler.queue[0])


### PR DESCRIPTION
Currently we report memory usage stats in ProcessLog output; however, this approach fails to capture real RAM usage as the check lands exactly when a process is completed, whereupon the memory it's using is potentially already freed. This adds a loop that polls current memory usage for the currently running OdinJob, and returns a log line with the highest observed RAM usage overall. The log reports OdinJob arguments so that we can trace the output to an individual job type, table, etc.