### PR TITLE
chore: Add retail.ticket_refunds, and corresponding schema exception

### DIFF
--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -79,6 +79,7 @@ TABLE_NUMERIC_OVERRIDES: dict[str, frozenset[str]] = {
     "retail.account_actions": frozenset({"hourOfDay"}),
     "retail.activations": frozenset({"hourOfDay"}),
     "retail.ticket_purchases": frozenset({"hourOfDay"}),
+    "retail.ticket_refunds": frozenset({"hourOfDay"}),
     "retail.tickets": frozenset({"hourOfDay"}),
     "retail.rider_entitlement_events": frozenset({"hourOfDay"}),
     "validation.scans": frozenset({"hourOfDay"}),

--- a/src/odin/ingestion/masabi/masabi_tables.py
+++ b/src/odin/ingestion/masabi/masabi_tables.py
@@ -10,6 +10,7 @@ TABLES_ALPHA = [
     # "view.validators",
     "retail.account_actions",
     "retail.tickets",
+    "retail.ticket_refunds",
     "validation.scans",
 ]
 


### PR DESCRIPTION
Asana ticket: https://app.asana.com/1/15492006741476/project/1212830297996795/task/1215460664182821?focus=true

Adds the retail.ticket_refunds table to the Masabi tables list (for Odin instance alpha.) This will start this table loading from the current Masabi start date, 2025-06-01.

Also adds the schema exception for ticket_refunds.hourOfDay, as that has the same type issue as the rest of those.