### PR TITLE
fix: removing duplicate log messages (in favor of OdinJob default logging)

### DIFF
--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -649,7 +649,8 @@ class CubicODSFact(OdinJob):
          - Merge CDC FACT conversion with existing FACT S3 dataset.
          - Upload merged FACT files to S3.
         """
-        log = ProcessLog("CubicODSFact", table=self.table)
+        # Lifecycle logging (process started/complete/run_delay_mins) is handled by the
+        # OdinJob base class; only swallowed exceptions are logged here.
         self.start_kwargs = {"table": self.table}
         next_run_secs = _default_run_interval()
 
@@ -679,16 +680,14 @@ class CubicODSFact(OdinJob):
                 )
                 snapshot_compare_to_history.complete()
             next_run_secs = self.load_cdc_records()
-
-            log.complete(run_interval=next_run_secs)
         # For development, other ODIN running...
         except pa.ArrowInvalid as e:
             self.start_kwargs["other_odin_running"] = "True"
-            log.failed(exception=e)
+            ProcessLog("CubicODSFact", table=self.table).failed(exception=e)
             return NEXT_RUN_IMMEDIATE
         except NoQlikHistoryError as e:
             self.start_kwargs["no_qlik_history_available"] = "True"
-            log.failed(exception=e)
+            ProcessLog("CubicODSFact", table=self.table).failed(exception=e)
 
         return next_run_secs
 

--- a/src/odin/generate/data_dictionary/dictionary.py
+++ b/src/odin/generate/data_dictionary/dictionary.py
@@ -159,7 +159,6 @@ class DataDictionary(OdinJob):
             ]
         }
         """
-        log = ProcessLog("DataDictionary")
         # Create and upload Data Dictionary json file.
         column_descriptions = fetch_AFC_column_descriptions()
         data_dictionary = [
@@ -188,7 +187,6 @@ class DataDictionary(OdinJob):
         upload_path = os.path.join(DATA_SPRINGBOARD, ODIN_DICTIONARY, db_obj_name)
         upload_file(db_file, upload_path)
 
-        log.complete(run_interval=NEXT_RUN_DEFAULT)
         return NEXT_RUN_DEFAULT
 
 

--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -658,7 +658,6 @@ class ArchiveAFCAPI(OdinJob):
         May 12, 2025 - API has been updated to always return results from "count" endpoint.
         June 2, 2025 - Updated to handle "static" and "transactional" table types.
         """
-        log = ProcessLog("ArchiveAFCAPI", table=self.table)
         self.start_kwargs = {"table": self.table}
         # Current timetout set to 10 mins, for full PROD deployment should be no more than 2 mins.
         self.req_pool = urllib3.PoolManager(
@@ -670,7 +669,6 @@ class ArchiveAFCAPI(OdinJob):
         self.load_job_ids()
         next_run_duration = self.re_run_check()
         self.sync_parquet()
-        log.complete(run_interval=next_run_duration)
         return next_run_duration
 
 

--- a/src/odin/ingestion/qlik/cubic_archive.py
+++ b/src/odin/ingestion/qlik/cubic_archive.py
@@ -352,9 +352,10 @@ class ArchiveCubicQlikTable(OdinJob):
             - if backlog of cdc files exists -> 5 mins
                 * when cdc files > half of max_cdc_files requested
         """
-        log = ProcessLog("ArchiveCubicQlikTable", table=self.table)
+        # Lifecycle logging (process started/complete/run_delay_mins) is handled by the
+        # OdinJob base class; only the swallowed RecentSnapshotError is logged here.
+        self.start_kwargs = {"table": self.table, "save_local": self.save_local}
         try:
-            self.start_kwargs = {"table": self.table, "save_local": self.save_local}
             self.archive_objects: List[str] = []
 
             next_run_secs = _default_run_interval()
@@ -368,12 +369,10 @@ class ArchiveCubicQlikTable(OdinJob):
             self.load_snapshots()
             self.load_cdc(cdc_files)
             self.move_objects()
-
-            log.complete(run_interval=next_run_secs)
         except RecentSnapshotError as e:
             self.start_kwargs["skipped_recent_snapshot"] = True
             next_run_secs = _default_run_interval()
-            log.failed(exception=e)
+            ProcessLog("ArchiveCubicQlikTable", table=self.table).failed(exception=e)
 
         return next_run_secs
 


### PR DESCRIPTION
Some OdinJobs have logging which is redundant with the logging built into the `OdinJob` base class. This clutters the logs, but also makes it difficult to profile activity (e.g.
```
index="odin-prod" "odin_instance=beta" complete process="CubicODSFact"  | stats sum(duration) by process
```
would give you double the expected duration)