### PR TITLE
fix: prevent invalid snapshot data loss case

### DIFF
--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -157,6 +157,9 @@ class CubicODSFact(OdinJob):
 
         try:
             self.fact_snapshot = str(fast_last_mod_ds_max(self.s3_export, "odin_snapshot"))
+            if self.fact_snapshot is None:
+                # Fail to prevent data loss case
+                raise ValueError("Data exists but found invalid fact_snapshot.")
         except IndexError:
             self.fact_snapshot = ""
 


### PR DESCRIPTION
Asana ticket: https://app.asana.com/1/15492006741476/project/1212830297996795/task/1216177340164530?focus=true (and others)

We have seen multiple cases of tables losing data via reconstructing fables from snapshot when they shouldn't have; most notably, edw.sale_transaction, but also edw.frm_src_crdb_acquirer_conf and others. This appears to be due to an empty (or otherwise invalid) parquet file being written, for which the check for an "odin_snapshot" value returns None. It is currently not certain what would cause such a parquet file to be written, but we suspect e.g. incorrect partitioning of data post-compression or partition periods which received no insert operations.

This PR causes the pipeline to simply fail a job when this case is encountered; this will require manual intervention to re-enable updates for the affected table, but will prevent data loss and allow us to further investigate the root cause.