### PR TITLE
fix: backfilling Masabi data (step 1)

### DIFF
--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -63,8 +63,8 @@ NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 # Exclusive lower bound for the live pipeline: 2025-06-01 00:00:00 UTC (ms).
 MASABI_START_TIMESTAMP_MS: int = 1_748_736_000_000
 
-# Exclusive lower bound for the gamma historical backfill: 2021-06-01 00:00:00 UTC (ms).
-MASABI_BACKFILL_START_TIMESTAMP_MS: int = 1_622_505_600_000
+# Exclusive lower bound for the gamma historical backfill: 2021-01-01 00:00:00 UTC (ms).
+MASABI_BACKFILL_START_TIMESTAMP_MS: int = 1_609_459_200_000
 
 _YAML_TYPE_MAP: dict[str, pl.DataType] = {
     "string": pl.String(),

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -12,7 +12,7 @@ import pyarrow.parquet as pq
 
 from odin.utils.logger import ProcessLog
 from odin.job import OdinJob, job_proc_schedule
-from odin.utils.locations import DATA_SPRINGBOARD, MASABI_DATA, MASABI_RESTRICTED
+from odin.utils.locations import DATA_SPRINGBOARD, MASABI_DATA, MASABI_RESTRICTED, MASABI_BACKFILL
 from odin.utils.aws.s3 import s3_folder
 from odin.utils.aws.s3 import download_object
 from odin.utils.aws.s3 import list_objects
@@ -60,8 +60,11 @@ NEXT_RUN_BETA = 60 * 15  # 15 minutes
 NEXT_RUN_IMMEDIATE = 60  # 1 minute
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
-# Exclusive lower bound for the initial historical backfill: 2025-06-01 00:00:00 UTC (ms).
+# Exclusive lower bound for the live pipeline: 2025-06-01 00:00:00 UTC (ms).
 MASABI_START_TIMESTAMP_MS: int = 1_748_736_000_000
+
+# Exclusive lower bound for the gamma historical backfill: 2021-06-01 00:00:00 UTC (ms).
+MASABI_BACKFILL_START_TIMESTAMP_MS: int = 1_622_505_600_000
 
 _YAML_TYPE_MAP: dict[str, pl.DataType] = {
     "string": pl.String(),
@@ -472,12 +475,22 @@ class ArchiveMasabi(OdinJob):
     """Basic Odin job stub for Masabi ingestion."""
 
     def __init__(self, table: str, restricted: bool = False) -> None:
-        """Create Job instance."""
+        """
+        Create Job instance.
+
+        On the gamma instance the job targets the historical backfill prefix
+        (MASABI_BACKFILL) instead of the live MASABI_DATA, so gamma can rebuild
+        the dataset from further back without disturbing the live pipeline.
+        The result will be swapped into MASABI_DATA by an odin-alpha-*
+        migration once caught up.
+        """
         self.table = table
         self.restricted = restricted
         self.start_kwargs = {"table": table, "restricted": restricted}
         if restricted:
             self.export_folder = s3_folder(os.path.join(DATA_SPRINGBOARD, MASABI_RESTRICTED, table))
+        elif _ODIN_INSTANCE == "gamma":
+            self.export_folder = s3_folder(os.path.join(DATA_SPRINGBOARD, MASABI_BACKFILL, table))
         else:
             self.export_folder = s3_folder(os.path.join(DATA_SPRINGBOARD, MASABI_DATA, table))
         self._last_request_time: float = 0.0
@@ -741,7 +754,11 @@ class ArchiveMasabi(OdinJob):
         """Read the pre-existing parquet files to get the start time for data."""
         log = ProcessLog("masabi_setup_job", table=self.table)
 
-        from_ts = MASABI_START_TIMESTAMP_MS
+        from_ts = (
+            MASABI_BACKFILL_START_TIMESTAMP_MS
+            if _ODIN_INSTANCE == "gamma"
+            else MASABI_START_TIMESTAMP_MS
+        )
         existing_ds = ds_from_path(self.export_folder)
         existing_ds_rows = existing_ds.count_rows()
         if existing_ds_rows:

--- a/src/odin/ingestion/masabi/masabi_tables.py
+++ b/src/odin/ingestion/masabi/masabi_tables.py
@@ -19,7 +19,9 @@ TABLES_BETA: list[str] = [
     "retail.activations",
 ]
 
-TABLES_GAMMA: list[str] = []
+TABLES_GAMMA: list[str] = [
+    "validation.scans" # DUPLICATED FROM ABOVE, REMOVE ONCE DATA IS BACKFILLED (see https://github.com/mbta/odin/pull/204)
+]
 
 TABLES_BY_INSTANCE = {
     "alpha": TABLES_ALPHA,

--- a/src/odin/ingestion/masabi/masabi_tables.py
+++ b/src/odin/ingestion/masabi/masabi_tables.py
@@ -20,7 +20,7 @@ TABLES_BETA: list[str] = [
 ]
 
 TABLES_GAMMA: list[str] = [
-    "validation.scans" # DUPLICATED FROM ABOVE, REMOVE ONCE DATA IS BACKFILLED (see https://github.com/mbta/odin/pull/204)
+    "validation.scans"  # DUPLICATED FROM ABOVE, REMOVE ONCE DATA IS BACKFILLED (see https://github.com/mbta/odin/pull/204)
 ]
 
 TABLES_BY_INSTANCE = {

--- a/src/odin/utils/locations.py
+++ b/src/odin/utils/locations.py
@@ -32,3 +32,6 @@ AFC_RESTRICTED = f"{ODIN_DATA}/sb/restricted"
 MASABI_DATA = f"{ODIN_DATA}/masabi/api"
 MASABI_RESTRICTED = f"{ODIN_DATA}/masabi/restricted"
 MASABI_TEMP = f"{ODIN_DATA}/masabi/temporary"
+# Destination for the historical backfill job. Kept separate from MASABI_DATA
+# so the live pipeline is undisturbed until the backfill is swapped in.
+MASABI_BACKFILL = f"{ODIN_DATA}/masabi/backfill"


### PR DESCRIPTION
This PR starts backfilling Masabi data, which currently only goes back 1 year, to fill in the remainder of the requested 5 years (to 2021-01-01). Since this is a temporary measure and we want the backfilling processing to happen on odin-gamma, all Masabi tables running on odin-gamma will run in backfill mode (i.e. syncing 5 years of data to `MASABI_BACKFILL`).

Once this is up to date, a new migration will be created to swap in this data.