### PR TITLE
Several runtime optimizations for CubicODSDelta

### DIFF
--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -505,10 +505,7 @@ class CubicODSDelta(OdinJob):
             return ""
         years_sql = ", ".join(str(y) for y in years)
         months_sql = ", ".join(str(m) for m in months)
-        return (
-            f' AND target."odin_year" IN ({years_sql})'
-            f' AND target."odin_month" IN ({months_sql})'
-        )
+        return f' AND target."odin_year" IN ({years_sql}) AND target."odin_month" IN ({months_sql})'
 
     def _merge_apply(self, source: pl.DataFrame, keys: list[str], watermark: str) -> dict:
         """Execute the delete/update/insert MERGE of `source` into silver."""

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -81,7 +81,7 @@ NEXT_RUN_IMMEDIATE = 60 * 5  # 5 minutes
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
 REBUILD_BATCH_SIZE = 10_000
-MAX_MERGE_RECORDS = 100_000
+MAX_MERGE_RECORDS = 500_000
 
 CDC_OPERS = ("I", "U", "D")
 
@@ -345,7 +345,7 @@ class CubicODSDelta(OdinJob):
             ) from exc
 
         self.silver = DeltaTable(self.silver_uri)
-        more_pending = self._read_cdc(max_seq_processed, limit=1).height
+        more_pending = cdc_df.height >= MAX_MERGE_RECORDS
 
         log.complete(
             cdc_records_processed=cdc_df.height,
@@ -355,30 +355,61 @@ class CubicODSDelta(OdinJob):
             more_pending=more_pending,
             **{f"merge_{k}": v for k, v in metrics.items()},
         )
-        return NEXT_RUN_IMMEDIATE if more_pending > 0 else _default_run_interval()
+        return NEXT_RUN_IMMEDIATE if more_pending else _default_run_interval()
 
     def _read_cdc(self, after_seq: str, limit: int) -> pl.DataFrame:
-        """Read up to `limit` CDC (I/U/D) records with seq > `after_seq`, seq-ascending."""
-        opers = ", ".join(f"'{o}'" for o in CDC_OPERS)
-        # The IS NULL arm plus NULLS FIRST puts any null-seq CDC record at the
-        # head of the very next batch, where the null_count assertion in
-        # _merge_cdc rejects it. With a bare `>` comparison NULL never matches,
-        # so such records would be silently skipped forever instead of raising.
-        conditions = [
-            "snapshot = ?",
-            f"header__change_oper IN ({opers})",
-            "(header__change_seq > ? OR header__change_seq IS NULL)",
-        ]
-        params = [self.history_snapshot, str(after_seq)]
-        sql = (
-            f"SELECT * FROM {self._read_history} "
-            f"WHERE {' AND '.join(conditions)} "
-            f"ORDER BY header__change_seq NULLS FIRST LIMIT {limit}"
-        )
+        """
+        Read the next batch of CDC (I/U/D) records with seq > `after_seq`.
 
+        Two steps so the wide read stays bounded no matter how well the parquet
+        prunes: first find the ceiling seq of the next `limit` records reading only
+        the seq column (a narrow top-k scan), then read full rows for
+        `after_seq < seq <= ceiling`. Taking the whole `<= ceiling` range (no LIMIT)
+        keeps records sharing the boundary seq in one batch, so the advancing
+        watermark can never strand tied rows.
+
+        The `IS NULL` arm surfaces any null-seq record (a data error) into
+        the batch, where the null_count assertion in _merge_cdc rejects it
+        instead of skipping it forever.
+        """
+        opers = ", ".join(f"'{o}'" for o in CDC_OPERS)
+        snap = self.history_snapshot
         con = _connect(self.history_root)
         try:
-            return con.execute(sql, params).pl()
+            # Step 1 — narrow: ceiling seq of the next `limit` records. Doubles as
+            # the "is there anything past the watermark?" probe.
+            window = (
+                con.execute(
+                    f"SELECT header__change_seq AS seq FROM {self._read_history} "
+                    f"WHERE snapshot = ? AND header__change_oper IN ({opers}) "
+                    "AND (header__change_seq > ? OR header__change_seq IS NULL) "
+                    f"ORDER BY header__change_seq NULLS FIRST LIMIT {limit}",
+                    [snap, str(after_seq)],
+                )
+                .pl()
+                .get_column("seq")
+            )
+            if window.len() == 0:
+                return pl.DataFrame()
+
+            # Step 2 — wide: full rows bounded to the window's seq range.
+            ceiling = window.drop_nulls().max()
+            conditions = ["snapshot = ?", f"header__change_oper IN ({opers})"]
+            params: list[str] = [snap]
+            if ceiling is None:
+                conditions.append("header__change_seq IS NULL")
+            else:
+                conditions.append(
+                    "((header__change_seq > ? AND header__change_seq <= ?) "
+                    "OR header__change_seq IS NULL)"
+                )
+                params += [str(after_seq), str(ceiling)]
+            return con.execute(
+                f"SELECT * FROM {self._read_history} "
+                f"WHERE {' AND '.join(conditions)} "
+                "ORDER BY header__change_seq NULLS FIRST",
+                params,
+            ).pl()
         finally:
             con.close()
 
@@ -448,6 +479,37 @@ class CubicODSDelta(OdinJob):
             )
         return source
 
+    def _merge_predicate(self, keys: list[str], source: pl.DataFrame) -> str:
+        """Build the MERGE match predicate (keys + optional partition constraint)."""
+        key_pred = " AND ".join(
+            f'(target."{k}" = source."{k}" OR (target."{k}" IS NULL AND source."{k}" IS NULL))'
+            for k in keys
+        )
+        return key_pred + self._partition_constraint(source)
+
+    def _partition_constraint(self, source: pl.DataFrame) -> str:
+        """
+        Return a partition-pruning clause for the merge, or '' when unsafe.
+
+        ` AND target.odin_year IN (...) AND target.odin_month IN (...)` restricts the
+        scan to the partitions the source touches. If any edw_inserted_dtm
+        is missing  we fall back to an unpruned full scan.
+        """
+        if "odin_year" not in source.columns or "odin_month" not in source.columns:
+            return ""
+        if source.get_column("edw_inserted_dtm").null_count() > 0:
+            return ""
+        years = sorted(source.get_column("odin_year").unique().to_list())
+        months = sorted(source.get_column("odin_month").unique().to_list())
+        if not years or not months:
+            return ""
+        years_sql = ", ".join(str(y) for y in years)
+        months_sql = ", ".join(str(m) for m in months)
+        return (
+            f' AND target."odin_year" IN ({years_sql})'
+            f' AND target."odin_month" IN ({months_sql})'
+        )
+
     def _merge_apply(self, source: pl.DataFrame, keys: list[str], watermark: str) -> dict:
         """Execute the delete/update/insert MERGE of `source` into silver."""
         assert self.silver is not None
@@ -457,10 +519,7 @@ class CubicODSDelta(OdinJob):
             f"primary key columns {sorted(missing)} absent from silver table for {self.table}"
         )
 
-        predicate = " AND ".join(
-            f'(target."{k}" = source."{k}" OR (target."{k}" IS NULL AND source."{k}" IS NULL))'
-            for k in keys
-        )
+        predicate = self._merge_predicate(keys, source)
 
         # Watermark columns are taken verbatim from the resolved CDC row; data
         # columns coalesce so a sparse update preserves untouched values.

--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -15,7 +15,7 @@ from odin.utils.runtime import schedule_sigterm_check
 from odin.ingestion.qlik.cubic_archive import schedule_cubic_archive_qlik
 from odin.generate.cubic.ods_fact import schedule_cubic_ods_fact_gen
 
-# from odin.generate.cubic.delta_ods import schedule_delta_ods
+from odin.generate.cubic.delta_ods import schedule_delta_ods
 from odin.ingestion.afc.afc_archive import schedule_afc_archive
 from odin.ingestion.afc.afc_restricted import schedule_restricted_afc_archive
 from odin.ingestion.masabi.masabi_archive import schedule_masabi_archive
@@ -76,7 +76,7 @@ def start():
         schedule_cubic_ods_fact_gen(schedule)
         # Delta-based silver pipeline; per-instance enablement is controlled by the
         # CUBIC_ODS_DELTA_TABLES_* lists (an empty list schedules nothing).
-        # schedule_delta_ods(schedule)
+        schedule_delta_ods(schedule)
         schedule_masabi_archive(schedule)
         schedule_afc_archive(schedule)
 

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -269,6 +269,102 @@ def test_merge_cdc_dated_table_derives_year_and_month(job):
     assert out.get_column("odin_month").to_list() == [1, 3]
 
 
+# Two partitions, each holding two keys whose ranges overlap the source key, so
+# only a partition constraint (not key-stat pruning) can skip a file.
+def _two_partition_history() -> "pa.Table":
+    from datetime import datetime
+
+    return dated_history_rows(
+        [
+            {"txn_id": 1, "amount": 10, "header__change_oper": "L",
+             "edw_inserted_dtm": datetime(2024, 1, 5)},
+            {"txn_id": 3, "amount": 30, "header__change_oper": "L",
+             "edw_inserted_dtm": datetime(2024, 1, 6)},
+            {"txn_id": 2, "amount": 20, "header__change_oper": "L",
+             "edw_inserted_dtm": datetime(2025, 3, 5)},
+            {"txn_id": 4, "amount": 40, "header__change_oper": "L",
+             "edw_inserted_dtm": datetime(2025, 3, 6)},
+        ]
+    )
+
+
+def test_merge_prunes_untouched_partitions(job):
+    """A CDC update carrying edw_inserted_dtm skips files outside its partition."""
+    from datetime import datetime
+
+    pipeline, write_history, _, _ = job
+    base = _two_partition_history()
+    update = dated_history_rows(
+        [{"txn_id": 2, "amount": 99, "header__change_oper": "U",
+          "header__change_seq": "0001", "edw_inserted_dtm": datetime(2025, 3, 5)}]
+    )
+    write_history(pa.concat_tables([base, update]))
+    pipeline._rebuild_silver()
+
+    cdc_df = pipeline._read_cdc("0", limit=100)
+    source = pipeline._build_merge_source(cdc_df, KEYS)
+    metrics = pipeline._merge_apply(source, KEYS, "0001")
+
+    # The (2024, 1) file is skipped by the partition constraint, not key stats.
+    assert metrics["num_target_files_skipped_during_scan"] >= 1
+    out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table()).sort("txn_id")
+    assert out.get_column("txn_id").to_list() == [1, 2, 3, 4]
+    assert out.filter(pl.col("txn_id") == 2).get_column("amount").to_list() == [99]
+
+
+def test_read_cdc_keeps_tied_boundary_seqs_together(job):
+    """The <= ceiling read returns all rows sharing the boundary seq, not a truncated k."""
+    pipeline, write_history, _, _ = job
+    write_history(
+        history_rows(
+            [
+                {"txn_id": 1, "header__change_oper": "I", "header__change_seq": "0001"},
+                {"txn_id": 2, "header__change_oper": "I", "header__change_seq": "0002"},
+                {"txn_id": 3, "header__change_oper": "I", "header__change_seq": "0002"},
+            ]
+        )
+    )
+    # limit=2 lands the ceiling on the tied 0002; the whole <= 0002 range comes back.
+    batch = pipeline._read_cdc("0", limit=2)
+    assert batch.height == 3
+    assert sorted(batch.get_column("header__change_seq").to_list()) == ["0001", "0002", "0002"]
+
+
+def test_read_cdc_empty_when_caught_up(job):
+    """No records past the watermark yields an empty batch (single narrow probe)."""
+    pipeline, write_history, _, _ = job
+    write_history(
+        history_rows(
+            [{"txn_id": 1, "header__change_oper": "I", "header__change_seq": "0001"}]
+        )
+    )
+    assert pipeline._read_cdc("0005", limit=100).height == 0
+
+
+def test_merge_no_prune_when_edw_missing(job):
+    """A CDC update missing edw_inserted_dtm falls back to an unpruned scan, still correct."""
+    pipeline, write_history, _, _ = job
+    base = _two_partition_history()
+    update = dated_history_rows(
+        [{"txn_id": 2, "amount": 99, "header__change_oper": "U", "header__change_seq": "0001"}]
+    )
+    write_history(pa.concat_tables([base, update]))
+    pipeline._rebuild_silver()
+
+    cdc_df = pipeline._read_cdc("0", limit=100)
+    source = pipeline._build_merge_source(cdc_df, KEYS)
+    metrics = pipeline._merge_apply(source, KEYS, "0001")
+
+    # No partition constraint, and key ranges overlap, so no file can be skipped.
+    assert metrics["num_target_files_skipped_during_scan"] == 0
+    out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table()).sort("txn_id")
+    row2 = out.filter(pl.col("txn_id") == 2)
+    assert row2.get_column("amount").to_list() == [99]
+    # Partition preserved from the retained edw_inserted_dtm (not clobbered to 0).
+    assert row2.get_column("odin_year").to_list() == [2025]
+    assert row2.get_column("odin_month").to_list() == [3]
+
+
 def test_rebuild_records_snapshot_and_initial_watermark(job):
     """Rebuild records the snapshot and a reset watermark in commit metadata."""
     pipeline, write_history, _, _ = job

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -276,14 +276,30 @@ def _two_partition_history() -> "pa.Table":
 
     return dated_history_rows(
         [
-            {"txn_id": 1, "amount": 10, "header__change_oper": "L",
-             "edw_inserted_dtm": datetime(2024, 1, 5)},
-            {"txn_id": 3, "amount": 30, "header__change_oper": "L",
-             "edw_inserted_dtm": datetime(2024, 1, 6)},
-            {"txn_id": 2, "amount": 20, "header__change_oper": "L",
-             "edw_inserted_dtm": datetime(2025, 3, 5)},
-            {"txn_id": 4, "amount": 40, "header__change_oper": "L",
-             "edw_inserted_dtm": datetime(2025, 3, 6)},
+            {
+                "txn_id": 1,
+                "amount": 10,
+                "header__change_oper": "L",
+                "edw_inserted_dtm": datetime(2024, 1, 5),
+            },
+            {
+                "txn_id": 3,
+                "amount": 30,
+                "header__change_oper": "L",
+                "edw_inserted_dtm": datetime(2024, 1, 6),
+            },
+            {
+                "txn_id": 2,
+                "amount": 20,
+                "header__change_oper": "L",
+                "edw_inserted_dtm": datetime(2025, 3, 5),
+            },
+            {
+                "txn_id": 4,
+                "amount": 40,
+                "header__change_oper": "L",
+                "edw_inserted_dtm": datetime(2025, 3, 6),
+            },
         ]
     )
 
@@ -295,8 +311,15 @@ def test_merge_prunes_untouched_partitions(job):
     pipeline, write_history, _, _ = job
     base = _two_partition_history()
     update = dated_history_rows(
-        [{"txn_id": 2, "amount": 99, "header__change_oper": "U",
-          "header__change_seq": "0001", "edw_inserted_dtm": datetime(2025, 3, 5)}]
+        [
+            {
+                "txn_id": 2,
+                "amount": 99,
+                "header__change_oper": "U",
+                "header__change_seq": "0001",
+                "edw_inserted_dtm": datetime(2025, 3, 5),
+            }
+        ]
     )
     write_history(pa.concat_tables([base, update]))
     pipeline._rebuild_silver()
@@ -334,9 +357,7 @@ def test_read_cdc_empty_when_caught_up(job):
     """No records past the watermark yields an empty batch (single narrow probe)."""
     pipeline, write_history, _, _ = job
     write_history(
-        history_rows(
-            [{"txn_id": 1, "header__change_oper": "I", "header__change_seq": "0001"}]
-        )
+        history_rows([{"txn_id": 1, "header__change_oper": "I", "header__change_seq": "0001"}])
     )
     assert pipeline._read_cdc("0005", limit=100).height == 0
 


### PR DESCRIPTION
Adds several performance optimizations to delta_ods.py:

- Increases MAX_MERGE_RECORDS to 500k, approximating the limit on fact_ods.py
- The 'more_pending' log flag is now based on whether we hit the merge records limit, rather than a separate scan of the fact tables
- When reading in CDC changes, instead of a single query for full data that uses LIMIT to restrict batch size, do two stages: first, a query just against the header__change_seq to find the upper and lower bound values that match the limit, and then a second query using those bounds. The previous version, which used `ORDER BY header__change_seq LIMIT {limit}` would require reading and sorting all header__change_seq values across all tables, rather than sorting only values that land within the interval.
- Restrict the merge predicate based on the odin month/year, so that the merge process is only touching files that need to be updated. This only works for updates which include the edw_inserted_dtm, but that looks like it's always the case (for tables that include that column.)