### PR TITLE
Set streamed_exec=False in delta merge

### DIFF
--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -552,6 +552,7 @@ class CubicODSDelta(OdinJob):
             error_on_type_mismatch=False,
             merge_schema=False,
             commit_properties=self._commit_state(watermark),
+            streamed_exec=False,
         )
         return (
             merger.when_matched_delete(predicate="source.header__change_oper = 'D'")


### PR DESCRIPTION
Possible optimization for the delta merge process, which seems to be the current bottleneck; we're not streaming in either case (we materialize `source` via `.to_arrow()`) and streamed_exec=True (the default) disables some methods deltalake uses to prune target files.