### PR TITLE
Additional fixes/improvements to delta fact job

### DIFF
--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -32,11 +32,13 @@ Two Qlik Replicate behaviors are relied on without a runtime check:
     ``ORDER BY header__change_seq LIMIT n`` and a strictly-greater watermark
     can never split records sharing a sequence across batches (which would
     permanently skip the cut-off records).
-  - "I" records are full row images (only "U" records may be sparse), so an
-    "I" is a per-key reset point: a winning "I" applies verbatim (NULL means
-    NULL), a winning "U" folds only across records at or after the key's
-    latest "I", and a batch containing an "I" replaces a matched target row
-    rather than coalescing with it. "D" images never contribute values.
+  - "I" records are full row images (only "U" records may be sparse). Both
+    "I" and "D" are therefore per-key *reset events*, and each key's latest
+    one alone decides its action: D deletes the row (trailing orphan updates
+    are dropped), I replaces/inserts it as the image plus trailing sparse
+    updates (NULL means NULL), and a key with neither patches the target row
+    sparsely. This resolution is batch-split invariant — see the reference
+    interpreter in delta_ods_property_test.py.
 
 Steps per run:
   1. Find the latest history ``snapshot=`` partition.
@@ -496,79 +498,74 @@ class CubicODSDelta(OdinJob):
         """
         Resolve CDC records to one final row per key for the silver MERGE.
 
-        Each key's winning (highest-seq) record decides the row's fate, and its
-        op decides how the data-column values are resolved — mirroring the
-        legacy ods_fact semantics:
+        Each key resolves to a single action, ``odin_resolved_oper``, decided by
+        the key's latest I or D record. Both are *reset events* — a delete ends
+        the row and an insert image wholly replaces it — so nothing recorded
+        before the latest one can affect the final row:
 
-          - winner "I": the insert image verbatim. I records are full row
-            images, so a NULL there means NULL and must not be backfilled from
-            older records (e.g. the pre-delete image of a delete-then-reinsert).
-          - winner "U": per-column latest non-null value folded across the
-            key's I/U records **at or after the key's latest I** — an insert
-            image is a full-image reset, so records behind it describe a row
-            version that no longer exists and must not leak values forward.
-            With no I in the batch, all U records fold and the MERGE coalesces
-            the remaining NULLs against the target row; with an I, the folded
-            row replaces the target verbatim. D-record images never contribute
-            values.
-          - winner "D": values are irrelevant (the MERGE deletes the row).
+          - "D" (latest reset is a delete): the row is deleted. Any trailing U
+            records are orphans (updates to a row that no longer exists) and
+            are dropped — the same outcome those events produce when a batch
+            boundary separates them from the delete.
+          - "I" (latest reset is an insert): the row becomes the insert image
+            overlaid with the non-null values of the trailing U records. A NULL
+            in that result means NULL (I images are full row images); on a
+            matched target row it replaces, never coalesces.
+          - "U" (no I or D in the batch): sparse update — per-column latest
+            non-null value across the key's U records; the MERGE coalesces the
+            remaining NULLs against the target row. Keys with no target row
+            are dropped.
 
-        Only U winners take the fold/join path; I and D winners pass through
-        verbatim, so peak memory scales with the update keys, not the batch.
+        This resolution is batch-split invariant: cutting the same event stream
+        into batches at different points yields the same final table. Verified
+        against the reference interpreter in delta_ods_property_test.py.
         """
         data_cols = [
             c
             for c in cdc_df.columns
             if c not in keys and c not in META_DROP_COLUMNS and c != "header__change_seq"
         ]
-        out_cols = [*keys, "header__change_seq", "header__change_oper", *data_cols]
-        sorted_desc = cdc_df.sort(by="header__change_seq", descending=True)
 
-        # One winning record per key: the highest header__change_seq.
-        winners = sorted_desc.unique(keys, keep="first").select(out_cols)
+        # Watermark lineage: each key's row carries its highest processed seq.
+        winners = cdc_df.group_by(keys).agg(pl.col("header__change_seq").max())
 
-        # I and D winners: values verbatim from the winning record.
-        verbatim = winners.filter(pl.col("header__change_oper") != "U")
-
-        # U winners: fold the latest non-null value per column across the key's
-        # I/U records, then re-attach the winner's seq/oper. The fold is anchored
-        # at the key's latest I record (its seq is the per-key reset point):
-        # an insert image is a full row image, so records behind it — including
-        # a pre-delete U's values — must not leak forward past it.
-        u_winners = winners.filter(pl.col("header__change_oper") == "U")
-        iu_records = sorted_desc.filter(pl.col("header__change_oper").is_in(("I", "U"))).join(
-            u_winners.select(keys), on=keys, how="semi", nulls_equal=True
+        # The reset event (latest I or D) per key; keys with neither resolve "U".
+        resets = (
+            cdc_df.select(*keys, "header__change_seq", "header__change_oper")
+            .filter(pl.col("header__change_oper").is_in(("I", "D")))
+            .group_by(keys)
+            .agg(
+                pl.col("header__change_oper")
+                .sort_by("header__change_seq")
+                .last()
+                .alias("odin_resolved_oper"),
+                pl.col("header__change_seq").max().alias("_reset_seq"),
+            )
         )
-        reset_seq = iu_records.group_by(keys).agg(
-            pl.col("header__change_seq")
-            .filter(pl.col("header__change_oper") == "I")
-            .max()
-            .alias("_reset_seq")
-        )
+
+        # Data values: latest non-null per column across the key's records at or
+        # after its reset (all records when there is none). By construction this
+        # folds I + trailing Us for "I" keys and only Us for "U" keys; for "D"
+        # keys it starts at the delete image itself, whose values are unused by
+        # the delete except edw_inserted_dtm, which _partition_constraint needs
+        # to keep the merge scan pruned (it names the deleted row's partition).
         folded = (
-            iu_records.join(reset_seq, on=keys, how="left", nulls_equal=True)
+            cdc_df.join(resets.select(*keys, "_reset_seq"), on=keys, how="left", nulls_equal=True)
             .filter(
                 pl.col("_reset_seq").is_null()
                 | (pl.col("header__change_seq") >= pl.col("_reset_seq"))
             )
+            .sort(by="header__change_seq", descending=True)
             .group_by(keys)
             .agg(pl.col(c).drop_nulls().first() for c in data_cols)
         )
-        updates = u_winners.select(*keys, "header__change_seq", "header__change_oper").join(
-            folded, on=keys, how="left", nulls_equal=True
-        )
-
-        # Insert gate: whether ANY record for the key is an "I" (false for keys
-        # seen only as U/D). Computed on a keys+oper projection to stay narrow.
-        has_insert = (
-            cdc_df.select(*keys, "header__change_oper")
-            .group_by(keys)
-            .agg(pl.col("header__change_oper").eq("I").any().alias("has_insert_base"))
-        )
 
         source = (
-            pl.concat([verbatim, updates.select(out_cols)], how="vertical")
-            .join(has_insert, on=keys, how="left", nulls_equal=True)
+            winners.join(
+                resets.select(*keys, "odin_resolved_oper"), on=keys, how="left", nulls_equal=True
+            )
+            .with_columns(pl.col("odin_resolved_oper").fill_null("U"))
+            .join(folded, on=keys, how="left", nulls_equal=True)
             .with_columns(pl.lit(self.history_snapshot, dtype=pl.String).alias("odin_snapshot"))
         )
         if "edw_inserted_dtm" in source.columns:
@@ -622,7 +619,15 @@ class CubicODSDelta(OdinJob):
         return f' AND target."odin_year" IN ({years_sql}) AND target."odin_month" IN ({months_sql})'
 
     def _merge_apply(self, source: pl.DataFrame, keys: list[str], watermark: str) -> dict:
-        """Execute the delete/update/insert MERGE of `source` into silver."""
+        """
+        Execute the MERGE of `source` into silver, one action per resolved op.
+
+        odin_resolved_oper maps directly onto the MERGE branches:
+          - "D": delete the matched row (unmatched: nothing to delete).
+          - "I": replace the matched row verbatim / insert when unmatched.
+          - "U": coalesce onto the matched row; unmatched U keys are orphan
+            updates (no live row to patch) and fall through untouched.
+        """
         assert self.silver is not None
         target_cols = self.silver.schema().to_arrow().names
         missing = set(keys) - set(target_cols)
@@ -630,32 +635,30 @@ class CubicODSDelta(OdinJob):
             f"primary key columns {sorted(missing)} absent from silver table for {self.table}"
         )
 
-        # On partitioned tables, any row this merge could INSERT (non-D with an
-        # insert base) must carry edw_inserted_dtm: an insert without it would
-        # land in the odin_year=0 partition, which partition-pruned merge scans
-        # never revisit (the pruning IN-lists are built from non-null source
-        # timestamps). Updates are exempt — they keep the target's partition.
+        # On partitioned tables, every "I"-resolved row (replaced or inserted
+        # with verbatim partition values) must carry edw_inserted_dtm: without
+        # it the row would land in the odin_year=0 partition, which
+        # partition-pruned merge scans never revisit. "U" rows are exempt —
+        # they keep the target's partition (see update_set below).
         if "odin_year" in source.columns:
-            insertable = source.filter(
-                pl.col("header__change_oper").ne("D") & pl.col("has_insert_base")
-            )
-            null_edw = insertable.get_column("edw_inserted_dtm").null_count()
+            inserts = source.filter(pl.col("odin_resolved_oper") == "I")
+            null_edw = inserts.get_column("edw_inserted_dtm").null_count()
             assert null_edw == 0, (
-                f"{null_edw} insertable CDC records for {self.table} carry a null "
+                f"{null_edw} insert-resolved CDC records for {self.table} carry a null "
                 "edw_inserted_dtm; inserted rows would land in the odin_year=0 "
                 "partition, which partition-pruned merges never revisit"
             )
 
         predicate = self._merge_predicate(keys, source)
 
-        # Matched rows with NO insert image in the batch (sparse update):
-        # watermark columns verbatim from the resolved CDC row; data columns
-        # coalesce so a sparse update preserves untouched target values.
-        # Partition columns follow edw_inserted_dtm: when no CDC record in the
-        # batch carried it for a key, source odin_year/odin_month degrade to 0
-        # while the coalesce keeps the target's edw_inserted_dtm — so the
-        # target's partition values must be kept too, or the row would silently
-        # move to the 0/0 partition and out of partition-pruned query results.
+        # "U" rows (sparse update): watermark columns verbatim from the
+        # resolved CDC row; data columns coalesce so untouched target values
+        # survive. Partition columns follow edw_inserted_dtm: when no CDC
+        # record in the batch carried it for a key, source odin_year/odin_month
+        # degrade to 0 while the coalesce keeps the target's edw_inserted_dtm —
+        # so the target's partition values must be kept too, or the row would
+        # silently move to the 0/0 partition and out of partition-pruned
+        # query results.
         passthrough = {"odin_snapshot", "header__change_seq"}
         partition_cols = {"odin_year", "odin_month"}
         source_cols = set(source.columns)
@@ -672,13 +675,12 @@ class CubicODSDelta(OdinJob):
                 )
             else:
                 update_set[col] = f'COALESCE(source."{col}", target."{col}")'
-        # Matched rows WITH an insert image in the batch (winner I, or winner U
-        # over a same-batch I) replace the row wholesale: the insert image is a
-        # full-image reset and the fold is anchored at it, so a NULL in the
+        # "I" rows replace a matched row wholesale (delete-then-reinsert within
+        # one batch, or a duplicate/replayed insert — the spec's idempotent
+        # upsert): the fold is anchored at the insert image, so a NULL in the
         # source means NULL — coalescing against the target would resurrect
-        # pre-reset values. Partition columns are safe verbatim: insertable
-        # rows are asserted above to carry edw_inserted_dtm, so they never
-        # degrade to the 0/0 partition.
+        # pre-reset values. Partition columns are safe verbatim per the assert
+        # above.
         replace_set = {
             col: f'source."{col}"' for col in target_cols if col in source_cols and col not in keys
         }
@@ -696,18 +698,11 @@ class CubicODSDelta(OdinJob):
             streamed_exec=False,
         )
         return (
-            merger.when_matched_delete(predicate="source.header__change_oper = 'D'")
-            .when_matched_update(
-                predicate=("source.header__change_oper != 'D' AND source.has_insert_base = true"),
-                updates=replace_set,
-            )
-            .when_matched_update(
-                predicate=("source.header__change_oper = 'U' AND source.has_insert_base = false"),
-                updates=update_set,
-            )
+            merger.when_matched_delete(predicate="source.odin_resolved_oper = 'D'")
+            .when_matched_update(predicate="source.odin_resolved_oper = 'I'", updates=replace_set)
+            .when_matched_update(predicate="source.odin_resolved_oper = 'U'", updates=update_set)
             .when_not_matched_insert(
-                predicate=("source.header__change_oper != 'D' AND source.has_insert_base = true"),
-                updates=insert_set,
+                predicate="source.odin_resolved_oper = 'I'", updates=insert_set
             )
             .execute()
         )

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -496,47 +496,60 @@ class CubicODSDelta(OdinJob):
         """
         Resolve CDC records to one final row per key for the silver MERGE.
 
-        Data-column values follow the legacy ods_fact semantics per winning op:
-          - final op "I": the insert image verbatim — I records are full row
+        Each key's winning (highest-seq) record decides the row's fate, and its
+        op decides how the data-column values are resolved — mirroring the
+        legacy ods_fact semantics:
+
+          - winner "I": the insert image verbatim. I records are full row
             images, so a NULL there means NULL and must not be backfilled from
             older records (e.g. the pre-delete image of a delete-then-reinsert).
-          - final op "U": per-column latest non-null value folded across the
+          - winner "U": per-column latest non-null value folded across the
             key's I/U records (sparse updates overlay the batch's insert base;
             the MERGE coalesces against the target row for the rest). D-record
             images never contribute values.
-          - final op "D": values are irrelevant (the MERGE deletes the row).
+          - winner "D": values are irrelevant (the MERGE deletes the row).
+
+        Only U winners take the fold/join path; I and D winners pass through
+        verbatim, so peak memory scales with the update keys, not the batch.
         """
         data_cols = [
             c
             for c in cdc_df.columns
             if c not in keys and c not in META_DROP_COLUMNS and c != "header__change_seq"
         ]
+        out_cols = [*keys, "header__change_seq", "header__change_oper", *data_cols]
         sorted_desc = cdc_df.sort(by="header__change_seq", descending=True)
-        latest = sorted_desc.unique(keys, keep="first").select(
-            keys + ["header__change_seq", "header__change_oper", *data_cols]
-        )
+
+        # One winning record per key: the highest header__change_seq.
+        winners = sorted_desc.unique(keys, keep="first").select(out_cols)
+
+        # I and D winners: values verbatim from the winning record.
+        verbatim = winners.filter(pl.col("header__change_oper") != "U")
+
+        # U winners: fold the latest non-null value per column across the key's
+        # I/U records, then re-attach the winner's seq/oper.
+        u_winners = winners.filter(pl.col("header__change_oper") == "U")
         folded = (
             sorted_desc.filter(pl.col("header__change_oper").is_in(("I", "U")))
+            .join(u_winners.select(keys), on=keys, how="semi", nulls_equal=True)
             .group_by(keys)
-            .agg(
-                *[pl.col(c).drop_nulls().first() for c in data_cols],
-                pl.col("header__change_oper").eq("I").any().alias("has_insert_base"),
-            )
+            .agg(pl.col(c).drop_nulls().first() for c in data_cols)
         )
+        updates = u_winners.select(*keys, "header__change_seq", "header__change_oper").join(
+            folded, on=keys, how="left", nulls_equal=True
+        )
+
+        # Insert gate: whether ANY record for the key is an "I" (false for keys
+        # seen only as U/D). Computed on a keys+oper projection to stay narrow.
+        has_insert = (
+            cdc_df.select(*keys, "header__change_oper")
+            .group_by(keys)
+            .agg(pl.col("header__change_oper").eq("I").any().alias("has_insert_base"))
+        )
+
         source = (
-            latest.join(folded, on=keys, how="left", nulls_equal=True, suffix="_folded")
-            .with_columns(
-                *[
-                    pl.when(pl.col("header__change_oper") == "U")
-                    .then(pl.col(f"{c}_folded"))
-                    .otherwise(pl.col(c))
-                    .alias(c)
-                    for c in data_cols
-                ],
-                # D-only keys have no I/U record to fold, hence no insert base.
-                pl.col("has_insert_base").fill_null(False),
-            )
-            .drop([f"{c}_folded" for c in data_cols])
+            pl.concat([verbatim, updates.select(out_cols)], how="vertical")
+            .join(has_insert, on=keys, how="left", nulls_equal=True)
             .with_columns(pl.lit(self.history_snapshot, dtype=pl.String).alias("odin_snapshot"))
         )
         if "edw_inserted_dtm" in source.columns:

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -663,8 +663,14 @@ class CubicODSDelta(OdinJob):
         months = sorted(source.get_column("odin_month").unique().to_list())
         if not years or not months:
             return ""
-        years_sql = ", ".join(str(y) for y in years)
-        months_sql = ", ".join(str(m) for m in months)
+        # Literals are cast to INT (Int32) to match the partition columns' type
+        # exactly: bare integer literals parse as Int64, and while DataFusion's
+        # planner coerces that, delta-rs also evaluates this predicate in strict
+        # non-coercing paths (kernel data skipping, concurrent-commit conflict
+        # checks) where an Int32/Int64 comparison is a hard error
+        # ("Invalid comparison operation: Int32 <= Int64").
+        years_sql = ", ".join(f"CAST({y} AS INT)" for y in years)
+        months_sql = ", ".join(f"CAST({m} AS INT)" for m in months)
         return f' AND target."odin_year" IN ({years_sql}) AND target."odin_month" IN ({months_sql})'
 
     def _merge_apply(self, source: pl.DataFrame, keys: list[str], watermark: str) -> dict:

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -32,10 +32,11 @@ Two Qlik Replicate behaviors are relied on without a runtime check:
     ``ORDER BY header__change_seq LIMIT n`` and a strictly-greater watermark
     can never split records sharing a sequence across batches (which would
     permanently skip the cut-off records).
-  - "I" records are full row images (only "U" records may be sparse), so
-    resolving a delete-then-reinsert within one batch to its final "I" record
-    yields the reinserted values; batch-level column coalescing only backfills
-    columns that are NULL in that final image.
+  - "I" records are full row images (only "U" records may be sparse). A key
+    whose winning record is an "I" takes that image verbatim — a NULL there
+    means NULL. Only "U" records apply sparsely (fold across the key's I/U
+    records, then coalesce against the target row); "D" images never
+    contribute values. This mirrors the legacy ods_fact semantics.
 
 Steps per run:
   1. Find the latest history ``snapshot=`` partition.
@@ -492,7 +493,19 @@ class CubicODSDelta(OdinJob):
             yield s3_file(path)
 
     def _build_merge_source(self, cdc_df: pl.DataFrame, keys: list[str]) -> pl.DataFrame:
-        """Resolve CDC records to one final row per key for the silver MERGE."""
+        """
+        Resolve CDC records to one final row per key for the silver MERGE.
+
+        Data-column values follow the legacy ods_fact semantics per winning op:
+          - final op "I": the insert image verbatim — I records are full row
+            images, so a NULL there means NULL and must not be backfilled from
+            older records (e.g. the pre-delete image of a delete-then-reinsert).
+          - final op "U": per-column latest non-null value folded across the
+            key's I/U records (sparse updates overlay the batch's insert base;
+            the MERGE coalesces against the target row for the rest). D-record
+            images never contribute values.
+          - final op "D": values are irrelevant (the MERGE deletes the row).
+        """
         data_cols = [
             c
             for c in cdc_df.columns
@@ -500,14 +513,31 @@ class CubicODSDelta(OdinJob):
         ]
         sorted_desc = cdc_df.sort(by="header__change_seq", descending=True)
         latest = sorted_desc.unique(keys, keep="first").select(
-            keys + ["header__change_seq", "header__change_oper"]
+            keys + ["header__change_seq", "header__change_oper", *data_cols]
         )
-        merged = sorted_desc.group_by(keys).agg(
-            *[pl.col(c).drop_nulls().first() for c in data_cols],
-            pl.col("header__change_oper").eq("I").any().alias("has_insert_base"),
+        folded = (
+            sorted_desc.filter(pl.col("header__change_oper").is_in(("I", "U")))
+            .group_by(keys)
+            .agg(
+                *[pl.col(c).drop_nulls().first() for c in data_cols],
+                pl.col("header__change_oper").eq("I").any().alias("has_insert_base"),
+            )
         )
-        source = latest.join(merged, on=keys, how="left", nulls_equal=True).with_columns(
-            pl.lit(self.history_snapshot, dtype=pl.String).alias("odin_snapshot")
+        source = (
+            latest.join(folded, on=keys, how="left", nulls_equal=True, suffix="_folded")
+            .with_columns(
+                *[
+                    pl.when(pl.col("header__change_oper") == "U")
+                    .then(pl.col(f"{c}_folded"))
+                    .otherwise(pl.col(c))
+                    .alias(c)
+                    for c in data_cols
+                ],
+                # D-only keys have no I/U record to fold, hence no insert base.
+                pl.col("has_insert_base").fill_null(False),
+            )
+            .drop([f"{c}_folded" for c in data_cols])
+            .with_columns(pl.lit(self.history_snapshot, dtype=pl.String).alias("odin_snapshot"))
         )
         if "edw_inserted_dtm" in source.columns:
             source = source.with_columns(
@@ -586,8 +616,8 @@ class CubicODSDelta(OdinJob):
 
         predicate = self._merge_predicate(keys, source)
 
-        # Watermark columns are taken verbatim from the resolved CDC row; data
-        # columns coalesce so a sparse update preserves untouched values.
+        # Matched "U" rows: watermark columns verbatim from the resolved CDC row;
+        # data columns coalesce so a sparse update preserves untouched values.
         # Partition columns follow edw_inserted_dtm: when no CDC record in the
         # batch carried it for a key, source odin_year/odin_month degrade to 0
         # while the coalesce keeps the target's edw_inserted_dtm — so the
@@ -609,6 +639,16 @@ class CubicODSDelta(OdinJob):
                 )
             else:
                 update_set[col] = f'COALESCE(source."{col}", target."{col}")'
+        # Matched "I" rows (delete-then-reinsert in one batch, or a duplicate
+        # insert) replace the row wholesale: the insert image is a full row
+        # image, so a NULL means NULL — coalescing against the target would
+        # resurrect pre-delete values. Matches the legacy ods_fact behavior
+        # (old row dropped, I record inserted verbatim). Partition columns are
+        # safe verbatim: insertable rows are asserted above to carry
+        # edw_inserted_dtm, so they never degrade to the 0/0 partition.
+        replace_set = {
+            col: f'source."{col}"' for col in target_cols if col in source_cols and col not in keys
+        }
         insert_set = {col: f'source."{col}"' for col in target_cols if col in source_cols}
 
         sigterm_check()
@@ -624,7 +664,8 @@ class CubicODSDelta(OdinJob):
         )
         return (
             merger.when_matched_delete(predicate="source.header__change_oper = 'D'")
-            .when_matched_update(predicate="source.header__change_oper != 'D'", updates=update_set)
+            .when_matched_update(predicate="source.header__change_oper = 'I'", updates=replace_set)
+            .when_matched_update(predicate="source.header__change_oper = 'U'", updates=update_set)
             .when_not_matched_insert(
                 predicate=("source.header__change_oper != 'D' AND source.has_insert_base = true"),
                 updates=insert_set,

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -50,6 +50,7 @@ Steps per run:
 
 import os
 import sched
+import tempfile
 from typing import Iterator
 
 import duckdb
@@ -132,9 +133,16 @@ def _long_run_interval() -> int:
     return NEXT_RUN_BETA if _ODIN_INSTANCE == "beta" else NEXT_RUN_LONG
 
 
-def _connect(path: str) -> duckdb.DuckDBPyConnection:
+def _connect(path: str, spill_dir: str) -> duckdb.DuckDBPyConnection:
     """Open a DuckDB connection, configuring S3 access for s3:// paths."""
     con = duckdb.connect()
+    # An in-memory DuckDB has no temp_directory, so memory-heavy queries OOM
+    # instead of spilling; point it at a job-scoped scratch folder.
+    os.makedirs(spill_dir, exist_ok=True)
+    con.execute(f"SET temp_directory = '{spill_dir}'")
+    # Progress bar output would spam the logging system.
+    con.execute("PRAGMA disable_progress_bar;")
+    con.execute("PRAGMA disable_print_progress_bar;")
     # Several queries per run read the same history files (schema describe, then
     # the narrow and wide CDC scans); cache parquet footers so they are fetched
     # from S3 once. The cache lives only as long as this run-scoped connection,
@@ -209,7 +217,10 @@ class CubicODSDelta(OdinJob):
     def _db(self) -> duckdb.DuckDBPyConnection:
         """Return the run-scoped DuckDB connection, creating it on first use."""
         if self._con is None:
-            self._con = _connect(self.history_root)
+            # OdinJob.start() provides tmpdir (cleaned after each run); direct
+            # step calls (tests) fall back to the system temp folder.
+            scratch = getattr(self, "tmpdir", None) or tempfile.gettempdir()
+            self._con = _connect(self.history_root, os.path.join(scratch, "duckdb_spill"))
         return self._con
 
     def _close_db(self) -> None:

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -32,11 +32,11 @@ Two Qlik Replicate behaviors are relied on without a runtime check:
     ``ORDER BY header__change_seq LIMIT n`` and a strictly-greater watermark
     can never split records sharing a sequence across batches (which would
     permanently skip the cut-off records).
-  - "I" records are full row images (only "U" records may be sparse). A key
-    whose winning record is an "I" takes that image verbatim — a NULL there
-    means NULL. Only "U" records apply sparsely (fold across the key's I/U
-    records, then coalesce against the target row); "D" images never
-    contribute values. This mirrors the legacy ods_fact semantics.
+  - "I" records are full row images (only "U" records may be sparse), so an
+    "I" is a per-key reset point: a winning "I" applies verbatim (NULL means
+    NULL), a winning "U" folds only across records at or after the key's
+    latest "I", and a batch containing an "I" replaces a matched target row
+    rather than coalescing with it. "D" images never contribute values.
 
 Steps per run:
   1. Find the latest history ``snapshot=`` partition.
@@ -504,9 +504,13 @@ class CubicODSDelta(OdinJob):
             images, so a NULL there means NULL and must not be backfilled from
             older records (e.g. the pre-delete image of a delete-then-reinsert).
           - winner "U": per-column latest non-null value folded across the
-            key's I/U records (sparse updates overlay the batch's insert base;
-            the MERGE coalesces against the target row for the rest). D-record
-            images never contribute values.
+            key's I/U records **at or after the key's latest I** — an insert
+            image is a full-image reset, so records behind it describe a row
+            version that no longer exists and must not leak values forward.
+            With no I in the batch, all U records fold and the MERGE coalesces
+            the remaining NULLs against the target row; with an I, the folded
+            row replaces the target verbatim. D-record images never contribute
+            values.
           - winner "D": values are irrelevant (the MERGE deletes the row).
 
         Only U winners take the fold/join path; I and D winners pass through
@@ -527,11 +531,26 @@ class CubicODSDelta(OdinJob):
         verbatim = winners.filter(pl.col("header__change_oper") != "U")
 
         # U winners: fold the latest non-null value per column across the key's
-        # I/U records, then re-attach the winner's seq/oper.
+        # I/U records, then re-attach the winner's seq/oper. The fold is anchored
+        # at the key's latest I record (its seq is the per-key reset point):
+        # an insert image is a full row image, so records behind it — including
+        # a pre-delete U's values — must not leak forward past it.
         u_winners = winners.filter(pl.col("header__change_oper") == "U")
+        iu_records = sorted_desc.filter(pl.col("header__change_oper").is_in(("I", "U"))).join(
+            u_winners.select(keys), on=keys, how="semi", nulls_equal=True
+        )
+        reset_seq = iu_records.group_by(keys).agg(
+            pl.col("header__change_seq")
+            .filter(pl.col("header__change_oper") == "I")
+            .max()
+            .alias("_reset_seq")
+        )
         folded = (
-            sorted_desc.filter(pl.col("header__change_oper").is_in(("I", "U")))
-            .join(u_winners.select(keys), on=keys, how="semi", nulls_equal=True)
+            iu_records.join(reset_seq, on=keys, how="left", nulls_equal=True)
+            .filter(
+                pl.col("_reset_seq").is_null()
+                | (pl.col("header__change_seq") >= pl.col("_reset_seq"))
+            )
             .group_by(keys)
             .agg(pl.col(c).drop_nulls().first() for c in data_cols)
         )
@@ -629,8 +648,9 @@ class CubicODSDelta(OdinJob):
 
         predicate = self._merge_predicate(keys, source)
 
-        # Matched "U" rows: watermark columns verbatim from the resolved CDC row;
-        # data columns coalesce so a sparse update preserves untouched values.
+        # Matched rows with NO insert image in the batch (sparse update):
+        # watermark columns verbatim from the resolved CDC row; data columns
+        # coalesce so a sparse update preserves untouched target values.
         # Partition columns follow edw_inserted_dtm: when no CDC record in the
         # batch carried it for a key, source odin_year/odin_month degrade to 0
         # while the coalesce keeps the target's edw_inserted_dtm — so the
@@ -652,13 +672,13 @@ class CubicODSDelta(OdinJob):
                 )
             else:
                 update_set[col] = f'COALESCE(source."{col}", target."{col}")'
-        # Matched "I" rows (delete-then-reinsert in one batch, or a duplicate
-        # insert) replace the row wholesale: the insert image is a full row
-        # image, so a NULL means NULL — coalescing against the target would
-        # resurrect pre-delete values. Matches the legacy ods_fact behavior
-        # (old row dropped, I record inserted verbatim). Partition columns are
-        # safe verbatim: insertable rows are asserted above to carry
-        # edw_inserted_dtm, so they never degrade to the 0/0 partition.
+        # Matched rows WITH an insert image in the batch (winner I, or winner U
+        # over a same-batch I) replace the row wholesale: the insert image is a
+        # full-image reset and the fold is anchored at it, so a NULL in the
+        # source means NULL — coalescing against the target would resurrect
+        # pre-reset values. Partition columns are safe verbatim: insertable
+        # rows are asserted above to carry edw_inserted_dtm, so they never
+        # degrade to the 0/0 partition.
         replace_set = {
             col: f'source."{col}"' for col in target_cols if col in source_cols and col not in keys
         }
@@ -677,8 +697,14 @@ class CubicODSDelta(OdinJob):
         )
         return (
             merger.when_matched_delete(predicate="source.header__change_oper = 'D'")
-            .when_matched_update(predicate="source.header__change_oper = 'I'", updates=replace_set)
-            .when_matched_update(predicate="source.header__change_oper = 'U'", updates=update_set)
+            .when_matched_update(
+                predicate=("source.header__change_oper != 'D' AND source.has_insert_base = true"),
+                updates=replace_set,
+            )
+            .when_matched_update(
+                predicate=("source.header__change_oper = 'U' AND source.has_insert_base = false"),
+                updates=update_set,
+            )
             .when_not_matched_insert(
                 predicate=("source.header__change_oper != 'D' AND source.has_insert_base = true"),
                 updates=insert_set,

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -401,8 +401,46 @@ class CubicODSDelta(OdinJob):
             cdc_watermark=max_seq_processed,
             more_pending=more_pending,
             **{f"merge_{k}": v for k, v in metrics.items()},
+            **self._partition_metrics(source),
         )
         return NEXT_RUN_IMMEDIATE if more_pending else _default_run_interval()
+
+    # How many per-partition row counts to spell out in the merge log line;
+    # beyond this the list is truncated (partitions_touched stays exact).
+    PARTITION_LOG_LIMIT = 24
+
+    def _partition_metrics(self, source: pl.DataFrame) -> dict:
+        """
+        Log fields describing the partitions a merge touches (dated tables only).
+
+        Reported from the merge source (the same values _partition_constraint
+        prunes by): how many distinct odin_year/odin_month partitions the batch
+        reaches and the row count landing in each, oldest first — the signal
+        for pathological update patterns (e.g. frequent history-wide sweeps).
+        Rows without edw_inserted_dtm have an unknown target partition; they
+        are counted separately and disable pruning for the whole merge.
+        """
+        if "odin_year" not in source.columns:
+            return {}
+        parts = (
+            source.filter(pl.col("edw_inserted_dtm").is_not_null())
+            .group_by("odin_year", "odin_month")
+            .len()
+            .sort("odin_year", "odin_month")
+        )
+        labels = [f"{y:04d}-{m:02d}={n}" for y, m, n in parts.iter_rows()]
+        if len(labels) > self.PARTITION_LOG_LIMIT:
+            hidden = len(labels) - self.PARTITION_LOG_LIMIT
+            labels = labels[: self.PARTITION_LOG_LIMIT] + [f"+{hidden} more"]
+        metrics = {
+            "partitions_touched": parts.height,
+            "partition_rows": ",".join(labels),
+            "partition_scan_pruned": bool(self._partition_constraint(source)),
+        }
+        unknown = source.get_column("edw_inserted_dtm").null_count()
+        if unknown:
+            metrics["partition_rows_unknown"] = unknown
+        return metrics
 
     def _read_cdc(self, after_seq: str, limit: int) -> pl.DataFrame:
         """

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -21,8 +21,11 @@ a contents-derived watermark would regress and re-read that batch forever.
 
 The source data is treated as untrusted: every run asserts the invariants it
 depends on (required columns present, primary keys declared and present, CDC
-records carry a change sequence, a load snapshot is non-empty). Violations raise
-rather than silently producing a corrupt silver table.
+records carry a change sequence, a load snapshot is non-empty, and — on
+year/month-partitioned tables — load and insert images carry a non-null
+``edw_inserted_dtm``, since a row without one would land in an odin_year=0
+partition that the pruned merge scan never revisits). Violations raise rather
+than silently producing a corrupt silver table.
 
 Two Qlik Replicate behaviors are relied on without a runtime check:
   - ``header__change_seq`` is unique per change record, so paging with
@@ -129,6 +132,12 @@ def _long_run_interval() -> int:
 def _connect(path: str) -> duckdb.DuckDBPyConnection:
     """Open a DuckDB connection, configuring S3 access for s3:// paths."""
     con = duckdb.connect()
+    # Several queries per run read the same history files (schema describe, then
+    # the narrow and wide CDC scans); cache parquet footers so they are fetched
+    # from S3 once. The cache lives only as long as this run-scoped connection,
+    # so a history file rewritten mid-run by cubic_archive is no worse than
+    # today: the in-flight read errors and the run is retried.
+    con.execute("SET parquet_metadata_cache = true;")
     if path.startswith("s3://"):
         con.execute("CREATE OR REPLACE SECRET secret (TYPE s3, PROVIDER credential_chain);")
     return con
@@ -156,6 +165,7 @@ class CubicODSDelta(OdinJob):
         self.history_columns: list[str] = []
         self.history_snapshot = ""
         self.part_columns: list[str] = []
+        self._con: duckdb.DuckDBPyConnection | None = None
 
     def run(self) -> int:
         """Materialize the latest snapshot + CDC into silver; return seconds to next run."""
@@ -190,6 +200,20 @@ class CubicODSDelta(OdinJob):
             self.start_kwargs["cdc_schema_incompatible"] = "True"
             log.failed(exception=exc)
             return _long_run_interval()
+        finally:
+            self._close_db()
+
+    def _db(self) -> duckdb.DuckDBPyConnection:
+        """Return the run-scoped DuckDB connection, creating it on first use."""
+        if self._con is None:
+            self._con = _connect(self.history_root)
+        return self._con
+
+    def _close_db(self) -> None:
+        """Close the run-scoped DuckDB connection, if open."""
+        if self._con is not None:
+            self._con.close()
+            self._con = None
 
     @property
     def _read_history(self) -> str:
@@ -245,11 +269,7 @@ class CubicODSDelta(OdinJob):
             f"unexpected snapshot partition name for {self.table}: {self.history_snapshot!r}"
         )
 
-        con = _connect(self.history_root)
-        try:
-            describe = con.execute(f"DESCRIBE SELECT * FROM {self._read_history}").pl()
-        finally:
-            con.close()
+        describe = self._db().execute(f"DESCRIBE SELECT * FROM {self._read_history}").pl()
         self.history_columns = describe.get_column("column_name").to_list()
 
         missing = set(REQUIRED_HISTORY_COLUMNS) - set(self.history_columns)
@@ -289,29 +309,53 @@ class CubicODSDelta(OdinJob):
             "WHERE snapshot = ? AND header__change_oper = 'L'"
         )
 
+        # Validate the load records BEFORE the overwrite: once write_deltalake
+        # commits, silver's contents and recorded snapshot have already advanced,
+        # so a post-write failure would leave a wedged (empty or mispartitioned)
+        # table that the next run no longer knows to rebuild.
+        self._check_load_records()
+
         sigterm_check()
-        con = _connect(self.history_root)
-        try:
-            reader = con.execute(
-                sql, [self.history_snapshot, self.history_snapshot]
-            ).fetch_record_batch(REBUILD_BATCH_SIZE)
-            write_deltalake(
-                self.silver_uri,
-                reader,
-                mode="overwrite",
-                schema_mode="overwrite",
-                partition_by=self.part_columns or None,
-                commit_properties=self._commit_state(INITIAL_WATERMARK),
-            )
-        finally:
-            con.close()
+        reader = (
+            self._db()
+            .execute(sql, [self.history_snapshot, self.history_snapshot])
+            .fetch_record_batch(REBUILD_BATCH_SIZE)
+        )
+        write_deltalake(
+            self.silver_uri,
+            reader,
+            mode="overwrite",
+            schema_mode="overwrite",
+            partition_by=self.part_columns or None,
+            commit_properties=self._commit_state(INITIAL_WATERMARK),
+        )
 
         self.silver = DeltaTable(self.silver_uri)
-        rows_loaded = delta_row_count(self.silver)
-        assert rows_loaded > 0, (
+        log.complete(rows_loaded=delta_row_count(self.silver))
+
+    def _check_load_records(self) -> None:
+        """Assert the snapshot's "L" records can produce a valid silver table."""
+        checks = ["count(*)"]
+        if self.part_columns:
+            checks.append('count(*) FILTER (WHERE "edw_inserted_dtm" IS NULL)')
+        row = (
+            self._db()
+            .execute(
+                f"SELECT {', '.join(checks)} FROM {self._read_history} "
+                "WHERE snapshot = ? AND header__change_oper = 'L'",
+                [self.history_snapshot],
+            )
+            .fetchone()
+        )
+        assert row is not None and row[0] > 0, (
             f"snapshot {self.history_snapshot} for {self.table} has no L (load) records"
         )
-        log.complete(rows_loaded=rows_loaded)
+        if self.part_columns:
+            assert row[1] == 0, (
+                f"snapshot {self.history_snapshot} for {self.table} has {row[1]} L (load) "
+                "records with a null edw_inserted_dtm; rows would land in the odin_year=0 "
+                "partition, which partition-pruned merges never revisit"
+            )
 
     # ------------------------------------------------------------------
     # CDC MERGE (silver update from I/U/D records)
@@ -374,44 +418,41 @@ class CubicODSDelta(OdinJob):
         """
         opers = ", ".join(f"'{o}'" for o in CDC_OPERS)
         snap = self.history_snapshot
-        con = _connect(self.history_root)
-        try:
-            # Step 1 — narrow: ceiling seq of the next `limit` records. Doubles as
-            # the "is there anything past the watermark?" probe.
-            window = (
-                con.execute(
-                    f"SELECT header__change_seq AS seq FROM {self._read_history} "
-                    f"WHERE snapshot = ? AND header__change_oper IN ({opers}) "
-                    "AND (header__change_seq > ? OR header__change_seq IS NULL) "
-                    f"ORDER BY header__change_seq NULLS FIRST LIMIT {limit}",
-                    [snap, str(after_seq)],
-                )
-                .pl()
-                .get_column("seq")
+        con = self._db()
+        # Step 1 — narrow: ceiling seq of the next `limit` records. Doubles as
+        # the "is there anything past the watermark?" probe.
+        window = (
+            con.execute(
+                f"SELECT header__change_seq AS seq FROM {self._read_history} "
+                f"WHERE snapshot = ? AND header__change_oper IN ({opers}) "
+                "AND (header__change_seq > ? OR header__change_seq IS NULL) "
+                f"ORDER BY header__change_seq NULLS FIRST LIMIT {limit}",
+                [snap, str(after_seq)],
             )
-            if window.len() == 0:
-                return pl.DataFrame()
+            .pl()
+            .get_column("seq")
+        )
+        if window.len() == 0:
+            return pl.DataFrame()
 
-            # Step 2 — wide: full rows bounded to the window's seq range.
-            ceiling = window.drop_nulls().max()
-            conditions = ["snapshot = ?", f"header__change_oper IN ({opers})"]
-            params: list[str] = [snap]
-            if ceiling is None:
-                conditions.append("header__change_seq IS NULL")
-            else:
-                conditions.append(
-                    "((header__change_seq > ? AND header__change_seq <= ?) "
-                    "OR header__change_seq IS NULL)"
-                )
-                params += [str(after_seq), str(ceiling)]
-            return con.execute(
-                f"SELECT * FROM {self._read_history} "
-                f"WHERE {' AND '.join(conditions)} "
-                "ORDER BY header__change_seq NULLS FIRST",
-                params,
-            ).pl()
-        finally:
-            con.close()
+        # Step 2 — wide: full rows bounded to the window's seq range.
+        ceiling = window.drop_nulls().max()
+        conditions = ["snapshot = ?", f"header__change_oper IN ({opers})"]
+        params: list[str] = [snap]
+        if ceiling is None:
+            conditions.append("header__change_seq IS NULL")
+        else:
+            conditions.append(
+                "((header__change_seq > ? AND header__change_seq <= ?) "
+                "OR header__change_seq IS NULL)"
+            )
+            params += [str(after_seq), str(ceiling)]
+        return con.execute(
+            f"SELECT * FROM {self._read_history} "
+            f"WHERE {' AND '.join(conditions)} "
+            "ORDER BY header__change_seq NULLS FIRST",
+            params,
+        ).pl()
 
     def _discover_keys(self, cdc_df: pl.DataFrame) -> list[str]:
         """Return the primary-key column names (lowercased) from the table DFM."""
@@ -480,9 +521,20 @@ class CubicODSDelta(OdinJob):
         return source
 
     def _merge_predicate(self, keys: list[str], source: pl.DataFrame) -> str:
-        """Build the MERGE match predicate (keys + optional partition constraint)."""
+        """
+        Build the MERGE match predicate (keys + optional partition constraint).
+
+        Each key uses plain equality when the source column carries no nulls:
+        with ``streamed_exec=False``, delta-rs derives an early-pruning predicate
+        from the source key min/max stats and skips target files whose key range
+        can't match — but only for simple equality conjunctions. The null-safe
+        ``OR (both NULL)`` form defeats that analysis, so it is emitted per key
+        and only when a null key value is actually present in the batch.
+        """
         key_pred = " AND ".join(
-            f'(target."{k}" = source."{k}" OR (target."{k}" IS NULL AND source."{k}" IS NULL))'
+            f'target."{k}" = source."{k}"'
+            if source.get_column(k).null_count() == 0
+            else f'(target."{k}" = source."{k}" OR (target."{k}" IS NULL AND source."{k}" IS NULL))'
             for k in keys
         )
         return key_pred + self._partition_constraint(source)
@@ -515,6 +567,22 @@ class CubicODSDelta(OdinJob):
         assert not missing, (
             f"primary key columns {sorted(missing)} absent from silver table for {self.table}"
         )
+
+        # On partitioned tables, any row this merge could INSERT (non-D with an
+        # insert base) must carry edw_inserted_dtm: an insert without it would
+        # land in the odin_year=0 partition, which partition-pruned merge scans
+        # never revisit (the pruning IN-lists are built from non-null source
+        # timestamps). Updates are exempt — they keep the target's partition.
+        if "odin_year" in source.columns:
+            insertable = source.filter(
+                pl.col("header__change_oper").ne("D") & pl.col("has_insert_base")
+            )
+            null_edw = insertable.get_column("edw_inserted_dtm").null_count()
+            assert null_edw == 0, (
+                f"{null_edw} insertable CDC records for {self.table} carry a null "
+                "edw_inserted_dtm; inserted rows would land in the odin_year=0 "
+                "partition, which partition-pruned merges never revisit"
+            )
 
         predicate = self._merge_predicate(keys, source)
 

--- a/tests/generate/cubic/delta_ods_property_test.py
+++ b/tests/generate/cubic/delta_ods_property_test.py
@@ -1,0 +1,193 @@
+"""
+Property-based tests for CubicODSDelta's CDC apply semantics.
+
+``apply_event`` below is the REFERENCE INTERPRETER: the executable spec of how
+one CDC event transforms one row. It is deliberately trivial — every semantic
+decision (I images are full row images where NULL means NULL; U records patch
+only their non-null columns; a U with no live row is an orphan and is dropped;
+D is delete-if-exists) is stated here once, in plain Python, and the real
+pipeline (batch resolution in ``_build_merge_source`` + Delta MERGE in
+``_merge_apply``) is treated as an optimized implementation of it.
+
+The property verified: for a random initial table, a random event stream, and a
+random split of that stream into batches, running the pipeline batch-by-batch
+produces exactly the table obtained by folding the events one at a time with
+the interpreter. This checks both value semantics and batch-split invariance
+(the outcome must not depend on where batch boundaries fall).
+
+Cases are generated from seeded ``random.Random`` instances, so failures are
+reproducible: re-run with the case number reported in the assertion message.
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+import polars as pl
+import pyarrow as pa
+import pytest
+
+from deltalake import DeltaTable, write_deltalake
+
+from odin.generate.cubic.delta_ods import CubicODSDelta
+
+KEYS = [1, 2, 3]
+DATA_COLS = ("amount", "status")
+N_CASES = 60
+TEST_SNAPSHOT = "20250101T000000Z"
+
+SILVER_SCHEMA = pa.schema(
+    [
+        pa.field("txn_id", pa.int64()),
+        pa.field("amount", pa.int64()),
+        pa.field("status", pa.large_string()),
+        pa.field("header__change_seq", pa.large_string()),
+        pa.field("odin_snapshot", pa.large_string()),
+    ]
+)
+
+BATCH_SCHEMA = {
+    "txn_id": pl.Int64,
+    "amount": pl.Int64,
+    "status": pl.String,
+    "header__change_seq": pl.String,
+    "header__change_oper": pl.String,
+}
+
+Row = dict[str, Any]
+
+
+# ----------------------------------------------------------------------
+# Reference interpreter (the executable spec)
+# ----------------------------------------------------------------------
+
+
+def apply_event(row: Row | None, event: Row) -> Row | None:
+    """Apply one CDC event to one row; the definition of the CDC semantics."""
+    oper = event["header__change_oper"]
+    if oper == "D":
+        # Delete-if-exists.
+        return None
+    if oper == "I":
+        # Full row image: the row becomes exactly the image; NULL means NULL.
+        return {
+            **{c: event[c] for c in DATA_COLS},
+            "header__change_seq": event["header__change_seq"],
+        }
+    if oper == "U":
+        if row is None:
+            # Orphan update: no live row to patch; the event is dropped.
+            return None
+        # Sparse update: NULL means "column not present", so patch only the
+        # non-null columns and keep the rest of the row.
+        patched = dict(row)
+        for c in DATA_COLS:
+            if event[c] is not None:
+                patched[c] = event[c]
+        patched["header__change_seq"] = event["header__change_seq"]
+        return patched
+    raise AssertionError(f"unknown oper {oper!r}")
+
+
+def reference_final(initial: dict[int, Row], events: list[Row]) -> dict[int, Row]:
+    """Fold `events` (in seq order) over `initial` one at a time."""
+    table = {k: dict(v) for k, v in initial.items()}
+    for event in sorted(events, key=lambda e: str(e["header__change_seq"])):
+        key = event["txn_id"]
+        row = apply_event(table.get(key), event)
+        if row is None:
+            table.pop(key, None)
+        else:
+            table[key] = row
+    return table
+
+
+# ----------------------------------------------------------------------
+# Case generation
+# ----------------------------------------------------------------------
+
+
+def generate_case(rng: Any) -> tuple[dict[int, Row], list[Row], list[list[Row]]]:
+    """Return (initial rows, event stream, the stream split into batches)."""
+    initial: dict[int, Row] = {}
+    for key in KEYS:
+        if rng.random() < 0.5:
+            initial[key] = {
+                "amount": rng.choice([None, *range(1, 6)]),
+                "status": rng.choice([None, "a", "b"]),
+                "header__change_seq": None,
+            }
+
+    n_events = rng.randint(1, 12)
+    events = [
+        {
+            "txn_id": rng.choice(KEYS),
+            "header__change_oper": rng.choices(["I", "U", "D"], weights=[3, 5, 2])[0],
+            "header__change_seq": f"{i + 1:04d}",
+            "amount": rng.choice([None, *range(10, 15)]),
+            "status": rng.choice([None, "x", "y"]),
+        }
+        for i in range(n_events)
+    ]
+
+    n_cuts = rng.randint(0, min(2, n_events - 1))
+    cuts = sorted(rng.sample(range(1, n_events), n_cuts)) if n_cuts else []
+    batches = [events[a:b] for a, b in zip([0, *cuts], [*cuts, n_events])]
+    return initial, events, batches
+
+
+# ----------------------------------------------------------------------
+# Pipeline execution
+# ----------------------------------------------------------------------
+
+
+def pipeline_final(silver_dir: str, initial: dict[int, Row], batches: list[list[Row]]) -> dict:
+    """Run the real resolver + Delta MERGE per batch; return the final table."""
+    rows = [{"txn_id": k, **v, "odin_snapshot": TEST_SNAPSHOT} for k, v in initial.items()]
+    write_deltalake(
+        silver_dir,
+        pa.Table.from_pylist(rows, schema=SILVER_SCHEMA),
+        mode="overwrite",
+        schema_mode="overwrite",
+    )
+
+    job = CubicODSDelta("EDW.TEST_TABLE")
+    job.silver_uri = silver_dir
+    job.history_snapshot = TEST_SNAPSHOT
+    for batch in batches:
+        batch_df = pl.DataFrame(batch, schema=BATCH_SCHEMA)
+        source = job._build_merge_source(batch_df, ["txn_id"])
+        watermark = str(batch_df.get_column("header__change_seq").max())
+        job.silver = DeltaTable(silver_dir)
+        job._merge_apply(source, ["txn_id"], watermark)
+
+    final = pl.from_arrow(DeltaTable(silver_dir).to_pyarrow_table())
+    assert isinstance(final, pl.DataFrame)
+    return {
+        row["txn_id"]: {c: row[c] for c in (*DATA_COLS, "header__change_seq")}
+        for row in final.to_dicts()
+    }
+
+
+# ----------------------------------------------------------------------
+# The property
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", range(N_CASES))
+def test_pipeline_matches_reference_interpreter(case, tmp_path):
+    """Batched resolver+MERGE ≡ one-event-at-a-time reference fold."""
+    import random
+
+    rng = random.Random(case)
+    initial, events, batches = generate_case(rng)
+
+    with patch("odin.generate.cubic.delta_ods.sigterm_check"):
+        actual = pipeline_final(str(tmp_path / "silver"), initial, batches)
+    expected = reference_final(initial, events)
+
+    assert actual == expected, (
+        f"case {case}: pipeline diverges from reference interpreter\n"
+        f"initial={initial}\nevents={events}\n"
+        f"batch sizes={[len(b) for b in batches]}\n"
+        f"actual={actual}\nexpected={expected}"
+    )

--- a/tests/generate/cubic/delta_ods_property_test.py
+++ b/tests/generate/cubic/delta_ods_property_test.py
@@ -35,15 +35,15 @@ DATA_COLS = ("amount", "status")
 N_CASES = 60
 TEST_SNAPSHOT = "20250101T000000Z"
 
-SILVER_SCHEMA = pa.schema(
-    [
-        pa.field("txn_id", pa.int64()),
-        pa.field("amount", pa.int64()),
-        pa.field("status", pa.large_string()),
-        pa.field("header__change_seq", pa.large_string()),
-        pa.field("odin_snapshot", pa.large_string()),
-    ]
-)
+
+_SILVER_SCHEMA_FIELDS: "list[pa.Field[Any]]" = [
+    pa.field("txn_id", pa.int64()),
+    pa.field("amount", pa.int64()),
+    pa.field("status", pa.large_string()),
+    pa.field("header__change_seq", pa.large_string()),
+    pa.field("odin_snapshot", pa.large_string()),
+]
+SILVER_SCHEMA = pa.schema(_SILVER_SCHEMA_FIELDS)
 
 BATCH_SCHEMA = {
     "txn_id": pl.Int64,

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -1024,6 +1024,71 @@ def test_merge_cdc_orphan_update_after_delete_drops_row(job):
     assert pipeline._read_state() == (TEST_SNAPSHOT, "0002")
 
 
+def test_partition_metrics_reports_touched_partitions(job):
+    """Merge logging reports distinct partitions with row counts, oldest first."""
+    from datetime import datetime
+
+    pipeline, _, _, _ = job
+    source = pl.DataFrame(
+        {
+            "edw_inserted_dtm": [
+                datetime(2025, 3, 1),
+                datetime(2024, 1, 5),
+                datetime(2024, 1, 6),
+            ],
+            "odin_year": [2025, 2024, 2024],
+            "odin_month": [3, 1, 1],
+        }
+    )
+    metrics = pipeline._partition_metrics(source)
+    assert metrics == {
+        "partitions_touched": 2,
+        "partition_rows": "2024-01=2,2025-03=1",
+        "partition_scan_pruned": True,
+    }
+
+
+def test_partition_metrics_counts_unknown_partition_rows(job):
+    """Rows without edw_inserted_dtm are counted as unknown and disable pruning."""
+    from datetime import datetime
+
+    pipeline, _, _, _ = job
+    source = pl.DataFrame(
+        {
+            "edw_inserted_dtm": [datetime(2025, 3, 1), None],
+            "odin_year": [2025, 0],
+            "odin_month": [3, 0],
+        }
+    )
+    metrics = pipeline._partition_metrics(source)
+    assert metrics["partitions_touched"] == 1
+    assert metrics["partition_rows"] == "2025-03=1"
+    assert metrics["partition_scan_pruned"] is False
+    assert metrics["partition_rows_unknown"] == 1
+
+
+def test_partition_metrics_truncates_long_lists_and_skips_undated(job):
+    """The per-partition list truncates beyond the limit; undated tables log nothing."""
+    from datetime import datetime
+
+    pipeline, _, _, _ = job
+    n = pipeline.PARTITION_LOG_LIMIT + 2
+    months = [datetime(2000 + i, 1 + i % 12, 1) for i in range(n)]
+    source = pl.DataFrame(
+        {
+            "edw_inserted_dtm": months,
+            "odin_year": [d.year for d in months],
+            "odin_month": [d.month for d in months],
+        }
+    )
+    metrics = pipeline._partition_metrics(source)
+    assert metrics["partitions_touched"] == n
+    assert metrics["partition_rows"].endswith(",+2 more")
+    assert metrics["partition_rows"].count(",") == pipeline.PARTITION_LOG_LIMIT
+
+    assert pipeline._partition_metrics(pl.DataFrame({"txn_id": [1]})) == {}
+
+
 def test_merge_predicate_plain_equality_for_null_free_keys(job):
     """
     Null-free source keys produce a plain-equality predicate.

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -464,8 +464,15 @@ def test_delete_only_batch_advances_watermark(job):
 
 
 def test_rebuild_silver_without_load_records_raises(job):
-    """A snapshot containing no L records is treated as an error."""
-    pipeline, write_history, _, _ = job
+    """
+    A snapshot containing no L records raises BEFORE silver is overwritten.
+
+    The check must precede the overwrite: a post-write failure would leave an
+    empty silver whose recorded snapshot has already advanced, so the next run
+    would not know to rebuild it.
+    """
+    pipeline, write_history, write_silver, read_silver = job
+    write_silver(silver_rows([{"txn_id": 7, "amount": 70, "status": "z"}]))
     write_history(
         history_rows(
             [
@@ -480,6 +487,62 @@ def test_rebuild_silver_without_load_records_raises(job):
     )
     with pytest.raises(AssertionError, match="no L"):
         pipeline._rebuild_silver()
+    # The existing silver table was not touched.
+    assert read_silver().get_column("txn_id").to_list() == [7]
+
+
+def test_rebuild_silver_null_edw_on_partitioned_table_raises(job):
+    """On a partitioned table, an L record with a null edw_inserted_dtm raises pre-write."""
+    from datetime import datetime
+
+    pipeline, write_history, _, _ = job
+    write_history(
+        dated_history_rows(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 10,
+                    "header__change_oper": "L",
+                    "edw_inserted_dtm": datetime(2025, 1, 15),
+                },
+                # Null edw_inserted_dtm would land this row in the unreachable
+                # odin_year=0 partition.
+                {"txn_id": 2, "amount": 20, "header__change_oper": "L"},
+            ]
+        )
+    )
+    with pytest.raises(AssertionError, match="edw_inserted_dtm"):
+        pipeline._rebuild_silver()
+
+
+def test_merge_cdc_insert_with_null_edw_raises(job):
+    """On a partitioned table, an insertable CDC record with null edw_inserted_dtm raises."""
+    from datetime import datetime
+
+    pipeline, write_history, _, _ = job
+    write_history(
+        dated_history_rows(
+            [
+                {
+                    "txn_id": 1,
+                    "amount": 10,
+                    "header__change_oper": "L",
+                    "edw_inserted_dtm": datetime(2025, 1, 15),
+                },
+                # Full-image I record missing edw_inserted_dtm: inserting it would
+                # put the row in the unreachable odin_year=0 partition.
+                {
+                    "txn_id": 2,
+                    "amount": 20,
+                    "header__change_oper": "I",
+                    "header__change_seq": "0001",
+                },
+            ]
+        )
+    )
+    pipeline._rebuild_silver()
+    with pytest.raises(AssertionError, match="edw_inserted_dtm"):
+        pipeline._merge_cdc("0")
 
 
 def test_merge_cdc_insert_adds_new_key(job):
@@ -661,6 +724,171 @@ def test_merge_cdc_null_change_seq_raises(job):
     )
     with pytest.raises(AssertionError, match="null header__change_seq"):
         pipeline._merge_cdc("0")
+
+
+def test_merge_cdc_reinsert_applies_insert_image_verbatim(job):
+    """
+    D→I for an existing key in one batch: the row becomes exactly the I image.
+
+    I records are full row images, so a NULL in the reinserted image means NULL.
+    The matched-update must not coalesce against the target (which would
+    resurrect the pre-delete status), and the batch fold must not backfill from
+    the D record's pre-delete image.
+    """
+    pipeline, write_history, write_silver, read_silver = job
+    write_silver(silver_rows([{"txn_id": 1, "amount": 10, "status": "a"}]))
+    write_history(
+        history_rows(
+            [
+                {"txn_id": 1, "amount": 10, "status": "a", "header__change_oper": "L"},
+                # D carries the full pre-delete image, as Qlik deletes often do.
+                {
+                    "txn_id": 1,
+                    "amount": 10,
+                    "status": "a",
+                    "header__change_oper": "D",
+                    "header__change_seq": "0001",
+                },
+                # Reinsert with status legitimately NULL.
+                {
+                    "txn_id": 1,
+                    "amount": 50,
+                    "status": None,
+                    "header__change_oper": "I",
+                    "header__change_seq": "0002",
+                },
+            ]
+        )
+    )
+    pipeline._merge_cdc("0")
+
+    row = read_silver()
+    assert row.get_column("txn_id").to_list() == [1]
+    assert row.get_column("amount").to_list() == [50]
+    assert row.get_column("status").to_list() == [None]
+
+
+def test_merge_cdc_reinsert_new_key_not_backfilled_from_older_records(job):
+    """
+    I→D→I for a new key in one batch: the inserted row is the final I image only.
+
+    NULLs in the winning insert image must not be backfilled from the key's
+    earlier records in the batch (the first insert's values).
+    """
+    pipeline, write_history, write_silver, read_silver = job
+    write_silver(silver_rows([{"txn_id": 9, "amount": 90, "status": "z"}]))
+    write_history(
+        history_rows(
+            [
+                {"txn_id": 9, "amount": 90, "status": "z", "header__change_oper": "L"},
+                {
+                    "txn_id": 1,
+                    "amount": 10,
+                    "status": "a",
+                    "header__change_oper": "I",
+                    "header__change_seq": "0001",
+                },
+                {"txn_id": 1, "header__change_oper": "D", "header__change_seq": "0002"},
+                {
+                    "txn_id": 1,
+                    "amount": 50,
+                    "status": None,
+                    "header__change_oper": "I",
+                    "header__change_seq": "0003",
+                },
+            ]
+        )
+    )
+    pipeline._merge_cdc("0")
+
+    row = read_silver().filter(pl.col("txn_id") == 1)
+    assert row.get_column("amount").to_list() == [50]
+    assert row.get_column("status").to_list() == [None]
+
+
+def test_merge_cdc_delete_image_never_contributes_values(job):
+    """
+    D→U (no I) for an existing key: sparse U nulls coalesce from the TARGET row.
+
+    The D record's image must not participate in the fold — legacy ods_fact
+    builds update overlays from U records only, on top of the existing fact row.
+    """
+    pipeline, write_history, write_silver, read_silver = job
+    write_silver(silver_rows([{"txn_id": 1, "amount": 10, "status": "a"}]))
+    write_history(
+        history_rows(
+            [
+                {"txn_id": 1, "amount": 10, "status": "a", "header__change_oper": "L"},
+                # D image carries a status that differs from the target row.
+                {
+                    "txn_id": 1,
+                    "amount": 10,
+                    "status": "zzz",
+                    "header__change_oper": "D",
+                    "header__change_seq": "0001",
+                },
+                # Sparse U: only amount supplied; status must come from target.
+                {
+                    "txn_id": 1,
+                    "amount": 99,
+                    "header__change_oper": "U",
+                    "header__change_seq": "0002",
+                },
+            ]
+        )
+    )
+    pipeline._merge_cdc("0")
+
+    row = read_silver()
+    assert row.get_column("amount").to_list() == [99]
+    assert row.get_column("status").to_list() == ["a"]
+
+
+def test_merge_predicate_plain_equality_for_null_free_keys(job):
+    """
+    Null-free source keys produce a plain-equality predicate.
+
+    delta-rs only derives an early-pruning predicate from source key stats for
+    simple equality conjunctions; the null-safe OR form must appear only when
+    the batch actually contains a null key value (and only on that key).
+    """
+    pipeline, _, _, _ = job
+    clean = pl.DataFrame({"txn_id": [1, 2], "other_id": [5, 6]})
+    assert pipeline._merge_predicate(["txn_id"], clean) == 'target."txn_id" = source."txn_id"'
+    assert pipeline._merge_predicate(["txn_id", "other_id"], clean) == (
+        'target."txn_id" = source."txn_id" AND target."other_id" = source."other_id"'
+    )
+
+    with_null = pl.DataFrame({"txn_id": [1, None], "other_id": [5, 6]})
+    assert pipeline._merge_predicate(["txn_id", "other_id"], with_null) == (
+        '(target."txn_id" = source."txn_id" '
+        'OR (target."txn_id" IS NULL AND source."txn_id" IS NULL)) '
+        'AND target."other_id" = source."other_id"'
+    )
+
+
+def test_merge_cdc_null_key_still_matches(job):
+    """A null primary key falls back to null-safe matching (update, not duplicate)."""
+    pipeline, write_history, write_silver, _ = job
+    write_silver(silver_rows([{"txn_id": None, "amount": 10, "status": "a"}]))
+    write_history(
+        history_rows(
+            [
+                {"txn_id": None, "amount": 10, "status": "a", "header__change_oper": "L"},
+                {
+                    "txn_id": None,
+                    "amount": 99,
+                    "header__change_oper": "U",
+                    "header__change_seq": "0001",
+                },
+            ]
+        )
+    )
+    pipeline._merge_cdc("0")
+
+    out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table())
+    assert out.height == 1
+    assert out.get_column("amount").to_list() == [99]
 
 
 def test_merge_cdc_quotes_reserved_word_columns(job):

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -1024,6 +1024,20 @@ def test_merge_cdc_orphan_update_after_delete_drops_row(job):
     assert pipeline._read_state() == (TEST_SNAPSHOT, "0002")
 
 
+def test_db_connection_spills_to_disk_without_progress_bar(job):
+    """The run-scoped connection can spill to disk and never prints progress."""
+    pipeline, _, _, _ = job
+    con = pipeline._db()
+
+    def setting(name: str) -> object:
+        return con.execute(f"SELECT current_setting('{name}')").fetchone()[0]
+
+    assert str(setting("temp_directory")).endswith("duckdb_spill")
+    assert setting("enable_progress_bar") is False
+    # Run-scoped: repeated calls reuse the same connection.
+    assert pipeline._db() is con
+
+
 def test_partition_metrics_reports_touched_partitions(job):
     """Merge logging reports distinct partitions with row counts, oldest first."""
     from datetime import datetime

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -726,6 +726,71 @@ def test_merge_cdc_null_change_seq_raises(job):
         pipeline._merge_cdc("0")
 
 
+def test_build_merge_source_one_row_per_key_with_correct_ops(job):
+    """
+    The merge source carries exactly one row per key across all op mixes.
+
+    Guards the verbatim/updates split: every key must land in exactly one of
+    the two paths, with the winning op and the insert gate resolved correctly.
+    """
+    pipeline, write_history, _, _ = job
+    write_history(
+        history_rows(
+            [
+                # key 1: I then sparse U -> winner U, insert base present
+                {
+                    "txn_id": 1,
+                    "amount": 10,
+                    "status": "a",
+                    "header__change_oper": "I",
+                    "header__change_seq": "0001",
+                },
+                {
+                    "txn_id": 1,
+                    "amount": 99,
+                    "header__change_oper": "U",
+                    "header__change_seq": "0002",
+                },
+                # key 2: U only -> winner U, no insert base
+                {
+                    "txn_id": 2,
+                    "amount": 20,
+                    "header__change_oper": "U",
+                    "header__change_seq": "0003",
+                },
+                # key 3: I only -> winner I
+                {
+                    "txn_id": 3,
+                    "amount": 30,
+                    "status": "c",
+                    "header__change_oper": "I",
+                    "header__change_seq": "0004",
+                },
+                # key 4: I then D -> winner D, insert base present
+                {
+                    "txn_id": 4,
+                    "amount": 40,
+                    "header__change_oper": "I",
+                    "header__change_seq": "0005",
+                },
+                {"txn_id": 4, "header__change_oper": "D", "header__change_seq": "0006"},
+                # key 5: D only -> winner D, no insert base
+                {"txn_id": 5, "header__change_oper": "D", "header__change_seq": "0007"},
+            ]
+        )
+    )
+    cdc_df = pipeline._read_cdc("0", limit=100)
+    source = pipeline._build_merge_source(cdc_df, KEYS).sort("txn_id")
+
+    assert source.get_column("txn_id").to_list() == [1, 2, 3, 4, 5]
+    assert source.get_column("header__change_oper").to_list() == ["U", "U", "I", "D", "D"]
+    assert source.get_column("has_insert_base").to_list() == [True, False, True, True, False]
+    # Key 1's fold: latest non-null amount wins, status backfilled from the I base.
+    row1 = source.filter(pl.col("txn_id") == 1)
+    assert row1.get_column("amount").to_list() == [99]
+    assert row1.get_column("status").to_list() == ["a"]
+
+
 def test_merge_cdc_reinsert_applies_insert_image_verbatim(job):
     """
     D→I for an existing key in one batch: the row becomes exactly the I image.
@@ -803,6 +868,98 @@ def test_merge_cdc_reinsert_new_key_not_backfilled_from_older_records(job):
 
     row = read_silver().filter(pl.col("txn_id") == 1)
     assert row.get_column("amount").to_list() == [50]
+    assert row.get_column("status").to_list() == [None]
+
+
+def test_merge_cdc_fold_does_not_reach_behind_insert_reset(job):
+    """
+    U→D→I→U in one batch: values older than the I must not leak forward.
+
+    The I is a full-image reset. A column that is NULL in the I and untouched
+    by the later sparse U is genuinely NULL — it must not be backfilled from
+    the pre-reset U record, nor from the matched target row.
+    """
+    pipeline, write_history, write_silver, read_silver = job
+    write_silver(silver_rows([{"txn_id": 1, "amount": 10, "status": "a"}]))
+    write_history(
+        history_rows(
+            [
+                {"txn_id": 1, "amount": 10, "status": "a", "header__change_oper": "L"},
+                # Pre-reset update sets a status that must NOT survive the reset.
+                {
+                    "txn_id": 1,
+                    "status": "zzz",
+                    "header__change_oper": "U",
+                    "header__change_seq": "0001",
+                },
+                {"txn_id": 1, "header__change_oper": "D", "header__change_seq": "0002"},
+                # Reinsert with status legitimately NULL.
+                {
+                    "txn_id": 1,
+                    "amount": 50,
+                    "status": None,
+                    "header__change_oper": "I",
+                    "header__change_seq": "0003",
+                },
+                # Post-reset sparse update touching only amount.
+                {
+                    "txn_id": 1,
+                    "amount": 60,
+                    "header__change_oper": "U",
+                    "header__change_seq": "0004",
+                },
+            ]
+        )
+    )
+    pipeline._merge_cdc("0")
+
+    row = read_silver()
+    assert row.get_column("txn_id").to_list() == [1]
+    assert row.get_column("amount").to_list() == [60]
+    # NULL from the reinserted image: not "zzz" (pre-reset U), not "a" (target).
+    assert row.get_column("status").to_list() == [None]
+
+
+def test_merge_cdc_insert_reset_new_key_uses_final_image(job):
+    """
+    I→D→I→U for a new key: the inserted row is the second image plus the U.
+
+    The first insert's values must not backfill NULLs in the reinserted image.
+    """
+    pipeline, write_history, write_silver, read_silver = job
+    write_silver(silver_rows([{"txn_id": 9, "amount": 90, "status": "z"}]))
+    write_history(
+        history_rows(
+            [
+                {"txn_id": 9, "amount": 90, "status": "z", "header__change_oper": "L"},
+                {
+                    "txn_id": 1,
+                    "amount": 10,
+                    "status": "a",
+                    "header__change_oper": "I",
+                    "header__change_seq": "0001",
+                },
+                {"txn_id": 1, "header__change_oper": "D", "header__change_seq": "0002"},
+                {
+                    "txn_id": 1,
+                    "amount": 50,
+                    "status": None,
+                    "header__change_oper": "I",
+                    "header__change_seq": "0003",
+                },
+                {
+                    "txn_id": 1,
+                    "amount": 60,
+                    "header__change_oper": "U",
+                    "header__change_seq": "0004",
+                },
+            ]
+        )
+    )
+    pipeline._merge_cdc("0")
+
+    row = read_silver().filter(pl.col("txn_id") == 1)
+    assert row.get_column("amount").to_list() == [60]
     assert row.get_column("status").to_list() == [None]
 
 

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -726,18 +726,18 @@ def test_merge_cdc_null_change_seq_raises(job):
         pipeline._merge_cdc("0")
 
 
-def test_build_merge_source_one_row_per_key_with_correct_ops(job):
+def test_build_merge_source_one_row_per_key_with_correct_resolution(job):
     """
     The merge source carries exactly one row per key across all op mixes.
 
-    Guards the verbatim/updates split: every key must land in exactly one of
-    the two paths, with the winning op and the insert gate resolved correctly.
+    Guards the reset-event resolution: each key's latest I or D decides its
+    odin_resolved_oper (U when the batch has neither), with folded values.
     """
     pipeline, write_history, _, _ = job
     write_history(
         history_rows(
             [
-                # key 1: I then sparse U -> winner U, insert base present
+                # key 1: I then sparse U -> resolves I (insert image + overlay)
                 {
                     "txn_id": 1,
                     "amount": 10,
@@ -751,14 +751,14 @@ def test_build_merge_source_one_row_per_key_with_correct_ops(job):
                     "header__change_oper": "U",
                     "header__change_seq": "0002",
                 },
-                # key 2: U only -> winner U, no insert base
+                # key 2: U only -> resolves U (sparse patch)
                 {
                     "txn_id": 2,
                     "amount": 20,
                     "header__change_oper": "U",
                     "header__change_seq": "0003",
                 },
-                # key 3: I only -> winner I
+                # key 3: I only -> resolves I
                 {
                     "txn_id": 3,
                     "amount": 30,
@@ -766,7 +766,7 @@ def test_build_merge_source_one_row_per_key_with_correct_ops(job):
                     "header__change_oper": "I",
                     "header__change_seq": "0004",
                 },
-                # key 4: I then D -> winner D, insert base present
+                # key 4: I then D -> resolves D
                 {
                     "txn_id": 4,
                     "amount": 40,
@@ -774,8 +774,14 @@ def test_build_merge_source_one_row_per_key_with_correct_ops(job):
                     "header__change_seq": "0005",
                 },
                 {"txn_id": 4, "header__change_oper": "D", "header__change_seq": "0006"},
-                # key 5: D only -> winner D, no insert base
+                # key 5: D then orphan U -> resolves D (trailing U dropped)
                 {"txn_id": 5, "header__change_oper": "D", "header__change_seq": "0007"},
+                {
+                    "txn_id": 5,
+                    "amount": 50,
+                    "header__change_oper": "U",
+                    "header__change_seq": "0008",
+                },
             ]
         )
     )
@@ -783,9 +789,16 @@ def test_build_merge_source_one_row_per_key_with_correct_ops(job):
     source = pipeline._build_merge_source(cdc_df, KEYS).sort("txn_id")
 
     assert source.get_column("txn_id").to_list() == [1, 2, 3, 4, 5]
-    assert source.get_column("header__change_oper").to_list() == ["U", "U", "I", "D", "D"]
-    assert source.get_column("has_insert_base").to_list() == [True, False, True, True, False]
-    # Key 1's fold: latest non-null amount wins, status backfilled from the I base.
+    assert source.get_column("odin_resolved_oper").to_list() == ["I", "U", "I", "D", "D"]
+    # Watermark lineage: each key carries its highest seq, even for D keys.
+    assert source.get_column("header__change_seq").to_list() == [
+        "0002",
+        "0003",
+        "0004",
+        "0006",
+        "0008",
+    ]
+    # Key 1's fold: latest non-null amount wins, status from the I base image.
     row1 = source.filter(pl.col("txn_id") == 1)
     assert row1.get_column("amount").to_list() == [99]
     assert row1.get_column("status").to_list() == ["a"]
@@ -963,20 +976,30 @@ def test_merge_cdc_insert_reset_new_key_uses_final_image(job):
     assert row.get_column("status").to_list() == [None]
 
 
-def test_merge_cdc_delete_image_never_contributes_values(job):
+def test_merge_cdc_orphan_update_after_delete_drops_row(job):
     """
-    D→U (no I) for an existing key: sparse U nulls coalesce from the TARGET row.
+    D→U (no I) for an existing key: the delete wins; the orphan U is dropped.
 
-    The D record's image must not participate in the fold — legacy ods_fact
-    builds update overlays from U records only, on top of the existing fact row.
+    The latest reset event (the D) decides the key's action. A U with no
+    subsequent insert image has no live row to patch — the same events split
+    across two batches would delete the row and drop the U, and resolution
+    must be batch-split invariant. (Legacy let the U resurrect the row when
+    both fell in one batch — a batch-boundary-dependent outcome.)
     """
     pipeline, write_history, write_silver, read_silver = job
-    write_silver(silver_rows([{"txn_id": 1, "amount": 10, "status": "a"}]))
+    write_silver(
+        silver_rows(
+            [
+                {"txn_id": 1, "amount": 10, "status": "a"},
+                {"txn_id": 2, "amount": 20, "status": "b"},
+            ]
+        )
+    )
     write_history(
         history_rows(
             [
                 {"txn_id": 1, "amount": 10, "status": "a", "header__change_oper": "L"},
-                # D image carries a status that differs from the target row.
+                {"txn_id": 2, "amount": 20, "status": "b", "header__change_oper": "L"},
                 {
                     "txn_id": 1,
                     "amount": 10,
@@ -984,7 +1007,6 @@ def test_merge_cdc_delete_image_never_contributes_values(job):
                     "header__change_oper": "D",
                     "header__change_seq": "0001",
                 },
-                # Sparse U: only amount supplied; status must come from target.
                 {
                     "txn_id": 1,
                     "amount": 99,
@@ -996,9 +1018,10 @@ def test_merge_cdc_delete_image_never_contributes_values(job):
     )
     pipeline._merge_cdc("0")
 
-    row = read_silver()
-    assert row.get_column("amount").to_list() == [99]
-    assert row.get_column("status").to_list() == ["a"]
+    # Row 1 deleted (orphan U dropped); row 2 untouched.
+    assert read_silver().get_column("txn_id").to_list() == [2]
+    # Watermark still advanced past the orphan U.
+    assert pipeline._read_state() == (TEST_SNAPSHOT, "0002")
 
 
 def test_merge_predicate_plain_equality_for_null_free_keys(job):


### PR DESCRIPTION
Another set of changes to the delta fact table creation job:

- Fix to the handling of an edge case of successive updates: if a row is deleted and then re-inserted, nulls in the insert would have been interpreted as 'columns not being updated,' and would have reverted to the (potentially non-null) values in the original deleted row. The merge logic is here changed so that nulls in inserts are always interpreted as explicit null values.
- Simplified merge predicate: Previously we changed the merge predicate to handle null values in key columns so that these rows are applied correctly; however, this theoretically should never happen, and is less efficient to compute. This now uses a simpler predicate when there are no nulls detected in the column, and falls back to the previous behavior otherwise.
- A single duckdb connection is maintained for the whole job history; file footer information and so forth is therefore kept in cache and doesn't have to be re-read multiple times.
- `_check_load_records` now asserts that there are L records in a snapshot file, to avoid dropping data if we receive an invalid/empty snapshot file.
- `_check_load_records` and `_merge_apply` now assert that edw_inserted_dtm is non-null, to avoid the possibility of sorting rows into a broken month=0/day=0 partition.