### PR TITLE
feat: Add disk monitoring to OdinJob

### DIFF
--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -223,9 +223,7 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler | None) -> None:
     return_manager = get_context("spawn").Manager()
     proc_return_val = return_manager.Value("i", NEXT_RUN_FAILED)
     proc_tmpdir_val = return_manager.Value("u", "")
-    proc = get_context("spawn").Process(
-        target=job.start, args=(proc_return_val, proc_tmpdir_val)
-    )
+    proc = get_context("spawn").Process(target=job.start, args=(proc_return_val, proc_tmpdir_val))
     proc.start()
 
     # Track the job subprocess' peak memory and disk spill from the parent so

--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from abc import abstractmethod
 from multiprocessing import get_context
+from multiprocessing.managers import ValueProxy
 from multiprocessing.process import BaseProcess
 from multiprocessing.sharedctypes import Synchronized
 from typing import Dict
@@ -19,7 +20,7 @@ from odin.utils.runtime import sigterm_check
 NEXT_RUN_DEFAULT = 60 * 60 * 6  # 6 hours
 NEXT_RUN_FAILED = 60 * 60 * 24  # 24 hours
 
-# How often the parent samples a running job subprocess' memory, in seconds
+# How often the parent samples a running job subprocess' memory and disk spill, in seconds
 MEM_POLL_INTERVAL_SECS = 1.0
 
 # Prefix for Odin temp directories to avoid conflicts with other processes
@@ -81,10 +82,17 @@ class OdinJob(ABC):
         :return: seconds to delay until next run of job
         """
 
-    def start(self, return_val: "Synchronized[int]") -> None:
+    def start(
+        self,
+        return_val: "Synchronized[int]",
+        tmpdir_val: "ValueProxy[str]",
+    ) -> None:
         """Start Odin job with logging."""
         sigterm_check()
         self.reset_tmpdir()
+        # Publish the tmpdir path so the parent can sample its on-disk size (DuckDB and
+        # other scratch spill into here) even after an OOM kill of this subprocess.
+        tmpdir_val.value = self.tmpdir
         run_delay_secs = NEXT_RUN_DEFAULT
         try:
             log = ProcessLog(
@@ -127,27 +135,59 @@ def _proc_tree_rss_mb(proc: psutil.Process) -> float:
     return rss / (1024 * 1024)
 
 
-def _monitor_proc_peak_rss_mb(proc: BaseProcess, poll_interval_secs: float) -> float:
-    """
-    Track the peak resident memory of a running job Process (and its children).
+def _dir_size_bytes(path: str) -> int:
+    """Total on-disk size of all regular files under ``path``, in bytes."""
+    total = 0
+    try:
+        with os.scandir(path) as entries:
+            for entry in entries:
+                try:
+                    if entry.is_dir(follow_symlinks=False):
+                        total += _dir_size_bytes(entry.path)
+                    elif entry.is_file(follow_symlinks=False):
+                        total += entry.stat(follow_symlinks=False).st_size
+                except OSError:
+                    # Entry vanished mid-walk (temp files churn quickly)
+                    continue
+    except OSError:
+        # Directory doesn't exist yet or was already cleaned up
+        return 0
+    return total
 
-    Sampling is done from the parent so the final reading survives an OOM kill of the
-    child. Blocks until ``proc`` exits, then returns the high-water mark in MB.
+
+def _monitor_proc_peak_usage(
+    proc: BaseProcess,
+    tmpdir_val: "ValueProxy[str]",
+    poll_interval_secs: float,
+) -> tuple[float, float]:
+    """
+    Track peak resident memory and peak temp-dir disk spill of a running job Process.
+
+    Sampling is done from the parent so the final readings survive an OOM kill of the
+    child (Fargate has no swap, so an over-budget job is killed outright rather than
+    paged out). DuckDB and other scratch spill into the job's tmpdir, so its on-disk
+    size is the disk-spill high-water mark. Blocks until ``proc`` exits.
 
     :param proc: the started job subprocess to monitor
-    :param poll_interval_secs: seconds between memory samples
+    :param tmpdir_val: shared value holding the child's tmpdir path (empty until the
+        child publishes it early in ``start``)
+    :param poll_interval_secs: seconds between samples
 
-    :return: peak resident memory observed, in MB
+    :return: (peak resident memory MB, peak tmpdir disk spill MB)
     """
     peak_mem_mb = 0.0
+    peak_spill_mb = 0.0
     try:
         mon = psutil.Process(proc.pid)
     except psutil.NoSuchProcess:
         # Job finished before we could attach; nothing to sample
         proc.join()
-        return peak_mem_mb
+        return peak_mem_mb, peak_spill_mb
 
     while True:
+        tmpdir = tmpdir_val.value
+        if tmpdir:
+            peak_spill_mb = max(peak_spill_mb, _dir_size_bytes(tmpdir) / (1024 * 1024))
         try:
             peak_mem_mb = max(peak_mem_mb, _proc_tree_rss_mb(mon))
         except psutil.NoSuchProcess:
@@ -157,7 +197,7 @@ def _monitor_proc_peak_rss_mb(proc: BaseProcess, poll_interval_secs: float) -> f
         proc.join(timeout=poll_interval_secs)
 
     proc.join()
-    return peak_mem_mb
+    return peak_mem_mb, peak_spill_mb
 
 
 def job_proc_schedule(job: OdinJob, schedule: sched.scheduler | None) -> None:
@@ -182,18 +222,25 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler | None) -> None:
 
     return_manager = get_context("spawn").Manager()
     proc_return_val = return_manager.Value("i", NEXT_RUN_FAILED)
-    proc = get_context("spawn").Process(target=job.start, args=(proc_return_val,))
+    proc_tmpdir_val = return_manager.Value("u", "")
+    proc = get_context("spawn").Process(
+        target=job.start, args=(proc_return_val, proc_tmpdir_val)
+    )
     proc.start()
 
-    # Track the job subprocess' peak memory from the parent so OOM-prone jobs can be
-    # identified by name and arguments (e.g. which table's update job is OOMing). This
-    # blocks until the job finishes, replacing a plain proc.join().
-    peak_mem_mb = _monitor_proc_peak_rss_mb(proc, MEM_POLL_INTERVAL_SECS)
+    # Track the job subprocess' peak memory and disk spill from the parent so
+    # resource-hungry jobs can be identified by name and arguments (e.g. which table's
+    # update job is OOMing or spilling). This blocks until the job finishes, replacing a
+    # plain proc.join().
+    peak_mem_mb, peak_spill_mb = _monitor_proc_peak_usage(
+        proc, proc_tmpdir_val, MEM_POLL_INTERVAL_SECS
+    )
 
     ProcessLog(
         "odin_job_peak_mem",
         job_type=job.__class__.__name__,
         peak_mem_mb=f"{peak_mem_mb:.2f}",
+        peak_spill_mb=f"{peak_spill_mb:.2f}",
         **job.start_kwargs,
     ).complete()
 
@@ -203,6 +250,7 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler | None) -> None:
             job_type=job.__class__.__name__,
             job_exit_code=proc.exitcode,
             peak_mem_mb=f"{peak_mem_mb:.2f}",
+            peak_spill_mb=f"{peak_spill_mb:.2f}",
             **job.start_kwargs,
         )
         fail_log.failed(SystemError("OdinJob killed by ECS."))

--- a/tests/job_test.py
+++ b/tests/job_test.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import sched
 import time
@@ -5,7 +6,7 @@ from multiprocessing import get_context
 
 from odin.job import OdinJob
 from odin.job import job_proc_schedule as real_job_proc_schedule
-from odin.job import _monitor_proc_peak_rss_mb
+from odin.job import _monitor_proc_peak_usage
 
 
 # caplog doesn't work in multiprocessing. this should be ok for now, but could be improved
@@ -22,7 +23,8 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler) -> None:
     """
     manager = get_context("spawn").Manager()
     return_val = manager.Value("i", 0)
-    job.start(return_val)
+    tmpdir_val = manager.Value("u", "")
+    job.start(return_val, tmpdir_val)
     schedule.enter(return_val.value, 1, job_proc_schedule, (job, schedule))
 
 
@@ -85,10 +87,14 @@ def test_odin_job(caplog, monkeypatch) -> None:
 
 
 # Defined at module level so the spawn context can pickle them
-def _mem_hog() -> None:
-    """Allocate ~50MB and hold it briefly so the parent can sample the footprint."""
+def _mem_and_disk_hog(tmpdir_val, spill_dir: str) -> None:
+    """Allocate ~50MB and spill ~20MB to ``spill_dir`` so the parent can sample both."""
+    tmpdir_val.value = spill_dir
     blob = bytearray(50 * 1024 * 1024)  # noqa: F841 -- keep ref so it stays resident
-    time.sleep(0.5)
+    with open(os.path.join(spill_dir, "spill.bin"), "wb") as spill_file:
+        spill_file.write(b"\0" * 20 * 1024 * 1024)
+        spill_file.flush()
+        time.sleep(0.5)
 
 
 class PeakMemJob(OdinJob):
@@ -101,15 +107,20 @@ class PeakMemJob(OdinJob):
         return 1000
 
 
-def test_monitor_proc_peak_rss_mb() -> None:
-    """A running subprocess' peak resident memory is captured from the parent."""
-    proc = get_context("spawn").Process(target=_mem_hog)
+def test_monitor_proc_peak_usage(tmp_path) -> None:
+    """A running subprocess' peak resident memory and disk spill are captured."""
+    manager = get_context("spawn").Manager()
+    tmpdir_val = manager.Value("u", "")
+    proc = get_context("spawn").Process(
+        target=_mem_and_disk_hog, args=(tmpdir_val, str(tmp_path))
+    )
     proc.start()
-    peak_mem_mb = _monitor_proc_peak_rss_mb(proc, 0.05)
+    peak_mem_mb, peak_spill_mb = _monitor_proc_peak_usage(proc, tmpdir_val, 0.05)
 
-    # Process is fully reaped and we observed a non-trivial footprint
+    # Process is fully reaped and we observed a non-trivial memory and disk footprint
     assert proc.exitcode == 0
     assert peak_mem_mb > 10.0
+    assert peak_spill_mb > 10.0
 
 
 def test_job_proc_schedule_logs_peak_mem(caplog) -> None:
@@ -122,5 +133,6 @@ def test_job_proc_schedule_logs_peak_mem(caplog) -> None:
     assert any("job_type=PeakMemJob" in m for m in peak_logs)
     assert any("table=retail.tickets" in m for m in peak_logs)
     assert any("peak_mem_mb=" in m for m in peak_logs)
+    assert any("peak_spill_mb=" in m for m in peak_logs)
 
     scheduler.cancel(scheduler.queue[0])

--- a/tests/job_test.py
+++ b/tests/job_test.py
@@ -111,9 +111,7 @@ def test_monitor_proc_peak_usage(tmp_path) -> None:
     """A running subprocess' peak resident memory and disk spill are captured."""
     manager = get_context("spawn").Manager()
     tmpdir_val = manager.Value("u", "")
-    proc = get_context("spawn").Process(
-        target=_mem_and_disk_hog, args=(tmpdir_val, str(tmp_path))
-    )
+    proc = get_context("spawn").Process(target=_mem_and_disk_hog, args=(tmpdir_val, str(tmp_path)))
     proc.start()
     peak_mem_mb, peak_spill_mb = _monitor_proc_peak_usage(proc, tmpdir_val, 0.05)
 


### PR DESCRIPTION
Disk usage from various processes spilling to disk is a common performance issue (particularly on AWS where the disk and CPU may not be proximate to each other) so this adds disk usage monitoring to the background OdinJob loop.