### PR TITLE
Remove several unnecessary log points

### DIFF
--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -180,7 +180,6 @@ class CubicODSDelta(OdinJob):
 
     def run(self) -> int:
         """Materialize the latest snapshot + CDC into silver; return seconds to next run."""
-        log = ProcessLog("CubicODSDelta", table=self.table)
         self.start_kwargs = {"table": self.table}
         try:
             self.silver = open_delta(self.silver_uri)
@@ -192,25 +191,12 @@ class CubicODSDelta(OdinJob):
                 cdc_watermark = INITIAL_WATERMARK
 
             next_run = self._merge_cdc(cdc_watermark)
-            log.complete(
-                run_interval=next_run,
-                history_snapshot=self.history_snapshot,
-                new_snapshot=self.history_snapshot != silver_snapshot,
-            )
-            return next_run
 
-        except NoQlikHistoryError as exc:
-            self.start_kwargs["no_qlik_history_available"] = "True"
-            log.failed(exception=exc)
-            return _long_run_interval()
-        except CommitFailedError as exc:
-            self.start_kwargs["delta_concurrent_modification"] = "True"
-            log.failed(exception=exc)
-            return NEXT_RUN_IMMEDIATE
-        except CDCSchemaIncompatibleError as exc:
-            self.start_kwargs["cdc_schema_incompatible"] = "True"
-            log.failed(exception=exc)
-            return _long_run_interval()
+            self.start_kwargs.update({
+                'history_snapshot': self.history_snapshot,
+                'new_snapshot': self.history_snapshot != silver_snapshot,
+            })
+            return next_run
         finally:
             self._close_db()
 

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -59,7 +59,6 @@ import polars as pl
 from deltalake import CommitProperties
 from deltalake import DeltaTable
 from deltalake import write_deltalake
-from deltalake.exceptions import CommitFailedError
 from deltalake.exceptions import SchemaMismatchError
 
 from odin.job import OdinJob
@@ -192,10 +191,12 @@ class CubicODSDelta(OdinJob):
 
             next_run = self._merge_cdc(cdc_watermark)
 
-            self.start_kwargs.update({
-                'history_snapshot': self.history_snapshot,
-                'new_snapshot': self.history_snapshot != silver_snapshot,
-            })
+            self.start_kwargs.update(
+                {
+                    "history_snapshot": self.history_snapshot,
+                    "new_snapshot": str(self.history_snapshot != silver_snapshot),
+                }
+            )
             return next_run
         finally:
             self._close_db()

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -293,7 +293,7 @@ class SchemaCheck:
         if not hits:
             return
 
-        log = ProcessLog("masabi_check_json_page")
+        log = ProcessLog("masabi_check_json_page", auto_start=False)
         sample = hits[0]
         schema_names = set(self.schema.names())
         hit_keys = set(sample.keys())
@@ -328,7 +328,7 @@ class SchemaCheck:
                     )
                     self.warned_columns.add(col)
 
-        log.complete()
+        log.complete(print_log=False)
 
     # ------------------------------------------------------------------
     # Row-level transforms

--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -86,12 +86,12 @@ class OdinJob(ABC):
         sigterm_check()
         self.reset_tmpdir()
         run_delay_secs = NEXT_RUN_DEFAULT
+        log = ProcessLog(
+            process=self.__class__.__name__,
+            auto_start=True,
+            **self.start_kwargs,
+        )
         try:
-            log = ProcessLog(
-                process=self.__class__.__name__,
-                **self.start_kwargs,
-            )
-
             run_delay_secs = self.run()
 
             assert isinstance(run_delay_secs, int)
@@ -192,6 +192,7 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler | None) -> None:
 
     ProcessLog(
         "odin_job_peak_mem",
+        auto_start=False,
         job_type=job.__class__.__name__,
         peak_mem_mb=f"{peak_mem_mb:.2f}",
         **job.start_kwargs,

--- a/src/odin/utils/parquet.py
+++ b/src/odin/utils/parquet.py
@@ -59,7 +59,6 @@ def pq_rows_and_bytes(path: str, num_rows: Optional[int] = None) -> Tuple[int, i
 
     :return: (num_rows, size_in_bytes)
     """
-    log = ProcessLog("pq_rows_and_bytes", path=path)
     if num_rows is None:
         num_rows = pq.read_metadata(path).num_rows
 
@@ -70,7 +69,6 @@ def pq_rows_and_bytes(path: str, num_rows: Optional[int] = None) -> Tuple[int, i
     else:
         size_bytes = os.path.getsize(path)
 
-    log.complete(num_rows=num_rows, size_bytes=size_bytes)
     return (num_rows, size_bytes)
 
 
@@ -85,7 +83,6 @@ def pq_rows_per_mb(source: Union[str, Sequence[str]], num_rows: Optional[int] = 
 
     :return: approximate number of rows equal to 1MB of parquet disk space
     """
-    log = ProcessLog("pq_rows_per_mb")
     paths = []
     if isinstance(source, str):
         if not source.endswith(".parquet"):
@@ -95,10 +92,8 @@ def pq_rows_per_mb(source: Union[str, Sequence[str]], num_rows: Optional[int] = 
             paths += [obj.path for obj in list_objects(source)]
         else:
             paths.append(source)
-        log.add_metadata(source=source)
     elif isinstance(source, Sequence):
         paths += source
-        log.add_metadata(num_sources=len(source))
 
     total_rows = 0
     total_mbs = 0.0
@@ -108,7 +103,6 @@ def pq_rows_per_mb(source: Union[str, Sequence[str]], num_rows: Optional[int] = 
         total_mbs += _bytes / (1024 * 1024)
 
     rows_per_mb = max(1_000, int(total_rows / total_mbs))
-    log.complete(rows_per_mb=rows_per_mb)
 
     return rows_per_mb
 


### PR DESCRIPTION
- Remove redundant CubicODSDelta top-level log, move fields unique to that to the top-level OdinJob logging.
- Remove logging from `pq_rows_and_bytes` and `pq_rows_per_mb`, since this was spamming the logs.
- `masabi_check_json_page` will now only emit logging if a schema discrepancy is found.