### PR TITLE
New mechanism for setting reschedule delay

### DIFF
--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -54,6 +54,7 @@ import tempfile
 from typing import Iterator
 
 import duckdb
+from duckdb import OutOfMemoryException
 import polars as pl
 import psutil
 
@@ -207,6 +208,11 @@ class CubicODSDelta(OdinJob):
                 }
             )
             return next_run
+        except OutOfMemoryException as e:
+            # This has typically been due to transient invalid allocations by duckdb; notably
+            # an actual non-duckdb OOM raises SystemError.
+            self.run_delay_secs = NEXT_RUN_IMMEDIATE
+            raise e
         finally:
             self._close_db()
 

--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -93,34 +93,34 @@ class OdinJob(ABC):
         # Publish the tmpdir path so the parent can sample its on-disk size (DuckDB and
         # other scratch spill into here) even after an OOM kill of this subprocess.
         tmpdir_val.value = self.tmpdir
-        run_delay_secs = NEXT_RUN_DEFAULT
+        self.run_delay_secs: int | None = None
         log = ProcessLog(
             process=self.__class__.__name__,
             auto_start=True,
             **self.start_kwargs,
         )
         try:
-            run_delay_secs = self.run()
-
-            assert isinstance(run_delay_secs, int)
+            self.run_delay_secs = self.run()
 
             log.complete(
-                run_delay_mins=f"{run_delay_secs / 60:.2f}",
+                run_delay_mins=f"{self.run_delay_secs / 60:.2f}",
                 **self.start_kwargs,
             )
 
         except Exception as exception:
-            run_delay_secs = NEXT_RUN_FAILED
+            if self.run_delay_secs is None:
+                self.run_delay_secs = NEXT_RUN_FAILED
             log.add_metadata(
                 print_log=False,
-                run_delay_mins=f"{run_delay_secs / 60:.2f}",
+                run_delay_mins=f"{self.run_delay_secs / 60:.2f}",
                 **self.start_kwargs,
             )
             log.failed(exception)
 
         finally:
             self.reset_tmpdir()
-            return_val.value = run_delay_secs
+            assert isinstance(self.run_delay_secs, int)
+            return_val.value = self.run_delay_secs
 
 
 def _proc_tree_rss_mb(proc: psutil.Process) -> float:


### PR DESCRIPTION
OdinJob's reschedule themselves after each run; the desired delay can vary based on errors, status, or so forth. Most jobs have an internal notion of their intended reschedule times; meanwhile, OdinJob has its own default and on-error reschedule times, and all errors would result in the OdinJob default on-error reschedule time. This PR makes the 'run_delay_secs' an object property instead of a local variable, so the particular job subclass can set it as needed. This also includes a relevant change to the delta fact table job using this mechanism.