### PR TITLE
Fix 'print_log=True' in ProcessLog.complete()

### DIFF
--- a/src/odin/utils/logger.py
+++ b/src/odin/utils/logger.py
@@ -132,7 +132,9 @@ class ProcessLog:
 
         :param metadata: any key/value pair to log
         """
-        self.add_metadata(print_log=False, **metadata)
+        if 'print_log' not in metadata:
+            metadata['print_log'] = False
+        self.add_metadata(**metadata)
 
         duration = time.monotonic() - self.start_time
         self.default_data["status"] = "complete"

--- a/src/odin/utils/logger.py
+++ b/src/odin/utils/logger.py
@@ -132,8 +132,8 @@ class ProcessLog:
 
         :param metadata: any key/value pair to log
         """
-        if 'print_log' not in metadata:
-            metadata['print_log'] = False
+        if "print_log" not in metadata:
+            metadata["print_log"] = False
         self.add_metadata(**metadata)
 
         duration = time.monotonic() - self.start_time


### PR DESCRIPTION
An earlier PR cleaned up logging, in one case by using 'print_log=False' to only print from the Masabi schema check when a discrepancy was found, saving some thousands of log lines per week. However, since ProcessLog internally uses its own `add_metadata` method in the `complete` method, and uses the same `print_log=False` mechanism to avoid double-printing, this causes an error. This change resolves that error in ProcessLog so that we can use `print_log` as expected.

[Asana](https://app.asana.com/1/15492006741476/project/1208949713596457/task/1216636342478474?focus=true)