### PR TITLE
feat: adding status logs for each table to S3

### DIFF
--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -49,8 +49,10 @@ Steps per run:
 """
 
 import os
+import re
 import sched
 import tempfile
+import time
 from typing import Iterator
 
 import duckdb
@@ -65,21 +67,32 @@ from deltalake.exceptions import SchemaMismatchError
 
 from odin.job import OdinJob
 from odin.job import job_proc_schedule
+from odin.utils.aws.s3 import list_objects
 from odin.utils.aws.s3 import list_partitions
 from odin.utils.aws.s3 import s3_file
 from odin.utils.aws.s3 import s3_folder
 from odin.utils.delta import open_delta
 from odin.utils.delta import row_count as delta_row_count
 from odin.utils.locations import CUBIC_ODS_DELTA_DATA
+from odin.utils.locations import CUBIC_ODS_DELTA_STATUS
 from odin.utils.locations import CUBIC_QLIK_PROCESSED
 from odin.utils.locations import CUBIC_QLIK_DATA
 from odin.utils.locations import DATA_ARCHIVE
 from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.logger import MdValues
 from odin.utils.logger import ProcessLog
+from odin.utils.parquet import ds_from_path
+from odin.utils.parquet import ds_metadata_min_max
 from odin.utils.runtime import sigterm_check
+from odin.utils.status import lag_seconds
+from odin.utils.status import progress_fields
+from odin.utils.status import publish_status
+from odin.utils.status import read_status
+from odin.utils.status import utc_now
 from odin.ingestion.qlik.dfm import QlikDFM
 from odin.ingestion.qlik.dfm import dfm_from_s3
 from odin.ingestion.qlik.utils import RE_SNAPSHOT_TS
+from odin.ingestion.qlik.utils import seq_as_datetime
 from odin.ingestion.qlik.tables import _ODIN_INSTANCE
 from odin.ingestion.qlik.tables import CUBIC_ODS_DELTA_TABLES_INSTANCE
 
@@ -103,6 +116,9 @@ HISTORY_SCAN_LIMIT = 50  # commits to scan back for the latest recorded position
 
 # DuckDB read expression over the snapshot-partitioned history parquet.
 READ_HISTORY = "read_parquet('{glob}', hive_partitioning = true, union_by_name = true)"
+
+# Hive partition values in a history object key, newest of which holds the newest seq.
+RE_HISTORY_YEAR_MONTH = re.compile(r"header__year=(\d+)/header__month=(\d+)/")
 
 # Columns required to be present in the history parquet for the job to run.
 REQUIRED_HISTORY_COLUMNS = (
@@ -186,10 +202,16 @@ class CubicODSDelta(OdinJob):
         self.history_snapshot = ""
         self.part_columns: list[str] = []
         self._con: duckdb.DuckDBPyConnection | None = None
+        # Post-merge position, published by _write_status. _merge_cdc advances the
+        # watermark; both stay at their defaults on the paths where it does no work.
+        self.cdc_watermark = INITIAL_WATERMARK
+        self.more_pending = False
+        self._run_started: float | None = None
 
     def run(self) -> int:
         """Materialize the latest snapshot + CDC into silver; return seconds to next run."""
         self.start_kwargs = {"table": self.table}
+        self._run_started = time.perf_counter()
         try:
             self.silver = open_delta(self.silver_uri)
             self._snapshot_check()
@@ -200,6 +222,7 @@ class CubicODSDelta(OdinJob):
                 cdc_watermark = INITIAL_WATERMARK
 
             next_run = self._merge_cdc(cdc_watermark)
+            self._write_status(next_run)
 
             self.start_kwargs.update(
                 {
@@ -377,8 +400,137 @@ class CubicODSDelta(OdinJob):
     # CDC MERGE (silver update from I/U/D records)
     # ------------------------------------------------------------------
 
+    def _newest_history_files(self) -> list[str]:
+        """
+        Return the history files of the newest header__year/header__month partition.
+
+        The partition values are read from the S3 keys themselves, so narrowing costs
+        one LIST and no file reads.
+
+        Picking the partition rather than the most recently modified file (the shape of
+        parquet.fast_last_mod_ds_max) is deliberate. Both find the same file while
+        history is only appended to, but cubic_archive rewrites files in place, and a
+        rewrite that touched an old month last would make the newest *file* hold old
+        sequences, reporting a too-low frontier and so a falsely caught-up lag.
+        Partition values come from the data's own event time, so they cannot be
+        reordered by a rewrite.
+
+        :return: paths in the newest partition, or every path if none are partitioned
+        """
+        objects = list_objects(
+            f"{self.history_root}snapshot={self.history_snapshot}/", in_filter=".parquet"
+        )
+        newest_key: tuple[int, int] | None = None
+        newest: list[str] = []
+        for obj in objects:
+            match = RE_HISTORY_YEAR_MONTH.search(obj.path)
+            if match is None:
+                continue
+            key = (int(match.group(1)), int(match.group(2)))
+            if newest_key is None or key > newest_key:
+                newest_key, newest = key, [obj.path]
+            elif key == newest_key:
+                newest.append(obj.path)
+        # Unpartitioned history (no header__year=/header__month= in the keys) still has
+        # a correct answer, just a more expensive one: read every footer.
+        return newest or [o.path for o in objects]
+
+    def _history_max_seq(self) -> str | None:
+        """
+        Return the newest header__change_seq in the current snapshot's history.
+
+        This is the reference point for the status file's true backlog: silver's
+        watermark measured against this goes to ~0 when the table is caught up, no
+        matter how old the data is.
+
+        Read from parquet row-group statistics over the newest partition only. DuckDB is
+        deliberately not used: it has no metadata-only path for a bare max(), so
+        `SELECT max(header__change_seq)` scans the whole column -- measured at ~51s
+        against EDW.SALE_TRANSACTION's 29GB of history, versus ~2s here. That cost lands
+        hardest exactly when a table is behind and rerunning every 5 minutes, which is
+        when the status file matters most.
+
+        header__year/header__month derive from header__timestamp, the same clock that
+        generates header__change_seq, so the newest partition holds the newest sequence
+        by construction rather than by luck of file ordering.
+        """
+        files = self._newest_history_files()
+        if not files:
+            return None
+        _, max_seq = ds_metadata_min_max(ds_from_path(files), "header__change_seq")
+        return None if max_seq is None else str(max_seq)
+
+    def _write_status(self, next_run_secs: int) -> None:
+        """
+        Publish this table's freshness status to S3 as JSON.
+
+        Called from run() rather than _merge_cdc so that every merge outcome -- no
+        silver, no CDC found, or records applied -- publishes exactly once.
+
+        Two lag measures, against different reference points:
+
+          * ``seq_lag_seconds`` -- silver's watermark vs the newest change_seq
+            upstream. The true backlog; ~0 means caught up regardless of data age.
+          * ``clock_lag_seconds`` -- silver's watermark vs wall clock. How old the
+            newest data is. Large for a rarely-updated table even when caught up.
+
+        Rates come from differencing the previous run's published object, and are
+        measured against ``seq_lag_seconds`` -- the true backlog -- so a quiet table
+        reports "caught up" rather than an ever-growing catch-up estimate.
+
+        :param next_run_secs: seconds until this table's next scheduled run
+        """
+        now = utc_now()
+        try:
+            history_max_seq = self._history_max_seq()
+        except Exception as exception:
+            # Degrade to the clock-only measure rather than fail the run: seq_lag is
+            # the better signal, but it is not worth a completed merge.
+            ProcessLog("delta_history_max_seq", table=self.table).failed(exception)
+            history_max_seq = None
+        seq_dt = seq_as_datetime(self.cdc_watermark)
+        history_seq_dt = seq_as_datetime(history_max_seq)
+        seq_lag = lag_seconds(history_seq_dt, seq_dt)
+        row_count = None if self.silver is None else delta_row_count(self.silver)
+        prev = read_status(CUBIC_ODS_DELTA_STATUS, self.table, self.scratch)
+        status: dict[str, MdValues] = {
+            "table": self.table,
+            "last_run": now.isoformat(),
+            "snapshot": self.history_snapshot,
+            "row_count": row_count,
+            "cdc_watermark": str(self.cdc_watermark),
+            "watermark_datetime": None if seq_dt is None else seq_dt.isoformat(),
+            "history_max_header__change_seq": (
+                None if history_max_seq is None else str(history_max_seq)
+            ),
+            "history_max_change_seq_datetime": (
+                None if history_seq_dt is None else history_seq_dt.isoformat()
+            ),
+            "seq_lag_seconds": seq_lag,
+            "clock_lag_seconds": lag_seconds(now, seq_dt),
+            "merge_budget_full": self.more_pending,
+            "next_run_seconds": next_run_secs,
+        }
+        status.update(
+            progress_fields(
+                prev=prev,
+                now=now,
+                run_duration_secs=(
+                    None if self._run_started is None else time.perf_counter() - self._run_started
+                ),
+                row_count=row_count,
+                watermark=seq_dt,
+                lag_secs=seq_lag,
+                # A rebuild resets the watermark to INITIAL_WATERMARK and rewrites every
+                # row, so differencing across it would report a fictional rate.
+                comparable=prev is not None and prev.get("snapshot") == self.history_snapshot,
+            )
+        )
+        publish_status(CUBIC_ODS_DELTA_STATUS, self.table, self.scratch, status)
+
     def _merge_cdc(self, after_seq: str) -> int:
         """Apply CDC records with seq > `after_seq` to silver; return the next-run interval."""
+        self.cdc_watermark = after_seq
         if self.silver is None:
             return _long_run_interval()
         log = ProcessLog("delta_merge_cdc", table=self.table)
@@ -406,6 +558,8 @@ class CubicODSDelta(OdinJob):
 
         self.silver = DeltaTable(self.silver_uri)
         more_pending = cdc_df.height >= MAX_MERGE_RECORDS
+        self.cdc_watermark = max_seq_processed
+        self.more_pending = more_pending
 
         log.complete(
             cdc_records_processed=cdc_df.height,

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -407,14 +407,6 @@ class CubicODSDelta(OdinJob):
         The partition values are read from the S3 keys themselves, so narrowing costs
         one LIST and no file reads.
 
-        Picking the partition rather than the most recently modified file (the shape of
-        parquet.fast_last_mod_ds_max) is deliberate. Both find the same file while
-        history is only appended to, but cubic_archive rewrites files in place, and a
-        rewrite that touched an old month last would make the newest *file* hold old
-        sequences, reporting a too-low frontier and so a falsely caught-up lag.
-        Partition values come from the data's own event time, so they cannot be
-        reordered by a rewrite.
-
         :return: paths in the newest partition, or every path if none are partitioned
         """
         objects = list_objects(
@@ -439,17 +431,6 @@ class CubicODSDelta(OdinJob):
         """
         Return the newest header__change_seq in the current snapshot's history.
 
-        This is the reference point for the status file's true backlog: silver's
-        watermark measured against this goes to ~0 when the table is caught up, no
-        matter how old the data is.
-
-        Read from parquet row-group statistics over the newest partition only. DuckDB is
-        deliberately not used: it has no metadata-only path for a bare max(), so
-        `SELECT max(header__change_seq)` scans the whole column -- measured at ~51s
-        against EDW.SALE_TRANSACTION's 29GB of history, versus ~2s here. That cost lands
-        hardest exactly when a table is behind and rerunning every 5 minutes, which is
-        when the status file matters most.
-
         header__year/header__month derive from header__timestamp, the same clock that
         generates header__change_seq, so the newest partition holds the newest sequence
         by construction rather than by luck of file ordering.
@@ -463,20 +444,6 @@ class CubicODSDelta(OdinJob):
     def _write_status(self, next_run_secs: int) -> None:
         """
         Publish this table's freshness status to S3 as JSON.
-
-        Called from run() rather than _merge_cdc so that every merge outcome -- no
-        silver, no CDC found, or records applied -- publishes exactly once.
-
-        Two lag measures, against different reference points:
-
-          * ``seq_lag_seconds`` -- silver's watermark vs the newest change_seq
-            upstream. The true backlog; ~0 means caught up regardless of data age.
-          * ``clock_lag_seconds`` -- silver's watermark vs wall clock. How old the
-            newest data is. Large for a rarely-updated table even when caught up.
-
-        Rates come from differencing the previous run's published object, and are
-        measured against ``seq_lag_seconds`` -- the true backlog -- so a quiet table
-        reports "caught up" rather than an ever-growing catch-up estimate.
 
         :param next_run_secs: seconds until this table's next scheduled run
         """

--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -388,18 +388,14 @@ class CubicODSFact(OdinJob):
         next_run_secs: int,
     ) -> None:
         """
-        Publish this table's freshness status to S3 as JSON.
+        Publish this table's freshness status to S3 as JSON
 
-        One object per table at ``<CUBIC_ODS_FACT_STATUS>/<table>.json``, overwritten on
-        every run, so that anyone with read access to the bucket can see how far behind
-        each fact table is.
+        Writes to ``<CUBIC_ODS_FACT_STATUS>/<table>.json``
 
-        Two lag measures are published, against different reference points:
+        Two lag measures are published:
 
           * ``seq_lag_seconds`` -- fact watermark vs the newest change_seq that exists
-            upstream in history. This is the true backlog: it goes to ~0 when the table
-            is caught up, no matter how old the data is, so a table that is merely quiet
-            reads as caught up rather than stale.
+            upstream in history.
           * ``clock_lag_seconds`` -- fact watermark vs wall clock at this run, i.e. how
             old the newest data is. A rarely-updated table shows a large value here even
             when fully caught up.

--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -1,5 +1,6 @@
 import os
 import sched
+import time
 from typing import Any
 from typing import List
 from typing import Tuple
@@ -12,11 +13,18 @@ import pyarrow.dataset as pd
 
 from odin.job import OdinJob
 from odin.job import job_proc_schedule
+from odin.utils.logger import MdValues
 from odin.utils.logger import ProcessLog
 from odin.utils.logger import free_disk_bytes
 from odin.utils.runtime import sigterm_check
+from odin.utils.status import lag_seconds
+from odin.utils.status import progress_fields
+from odin.utils.status import publish_status
+from odin.utils.status import read_status
+from odin.utils.status import utc_now
 from odin.utils.locations import DATA_SPRINGBOARD
 from odin.utils.locations import CUBIC_ODS_FACT_DATA
+from odin.utils.locations import CUBIC_ODS_FACT_STATUS
 from odin.utils.locations import CUBIC_QLIK_DATA
 from odin.utils.locations import DATA_ARCHIVE
 from odin.utils.locations import CUBIC_QLIK_PROCESSED
@@ -36,6 +44,7 @@ from odin.utils.aws.s3 import upload_file
 from odin.utils.aws.s3 import s3_folder
 from odin.ingestion.qlik.dfm import dfm_from_s3
 from odin.ingestion.qlik.dfm import QlikDFM
+from odin.ingestion.qlik.utils import seq_as_datetime
 from odin.ingestion.qlik.tables import _ODIN_INSTANCE
 from odin.ingestion.qlik.tables import CUBIC_ODS_TABLES_INSTANCE
 
@@ -126,6 +135,8 @@ class CubicODSFact(OdinJob):
         self.s3_source = os.path.join(DATA_SPRINGBOARD, CUBIC_QLIK_DATA, table)
         self.s3_export = os.path.join(DATA_SPRINGBOARD, CUBIC_ODS_FACT_DATA, table)
         self.start_kwargs = {"table": table}
+        # Set by load_cdc_records; the denominator for the status file's rates.
+        self._run_started: float | None = None
         self.history_drop_columns = [
             "header__year",
             "header__month",
@@ -367,6 +378,87 @@ class CubicODSFact(OdinJob):
 
         return all_cdc_frames, total_cdc_rows, total_cdc_nbytes
 
+    def write_status(
+        self,
+        max_seq: Any,
+        history_max_seq: Any,
+        row_count: int,
+        cdc_budget_nearly_full: bool,
+        cdc_records_pending: int,
+        next_run_secs: int,
+    ) -> None:
+        """
+        Publish this table's freshness status to S3 as JSON.
+
+        One object per table at ``<CUBIC_ODS_FACT_STATUS>/<table>.json``, overwritten on
+        every run, so that anyone with read access to the bucket can see how far behind
+        each fact table is.
+
+        Two lag measures are published, against different reference points:
+
+          * ``seq_lag_seconds`` -- fact watermark vs the newest change_seq that exists
+            upstream in history. This is the true backlog: it goes to ~0 when the table
+            is caught up, no matter how old the data is, so a table that is merely quiet
+            reads as caught up rather than stale.
+          * ``clock_lag_seconds`` -- fact watermark vs wall clock at this run, i.e. how
+            old the newest data is. A rarely-updated table shows a large value here even
+            when fully caught up.
+
+        A table that cannot keep up with CDC volume is the one with a large
+        ``seq_lag_seconds``, typically alongside ``cdc_budget_nearly_full``.
+
+        Status is best-effort telemetry: a failure here is logged and swallowed so it can
+        never fail an otherwise successful load.
+
+        :param max_seq: max header__change_seq in the fact table after this run
+        :param history_max_seq: max header__change_seq available upstream in history
+        :param row_count: fact table row count after this run
+        :param cdc_budget_nearly_full: run consumed >=90% of its CDC accumulation budget
+        :param cdc_records_pending: CDC records still unprocessed (a preview count capped
+            by CDC_BATCH_MAX_NBYTES, so a floor rather than an exact backlog)
+        :param next_run_secs: seconds until this table's next scheduled run
+        """
+        now = utc_now()
+        seq_dt = seq_as_datetime(max_seq)
+        history_seq_dt = seq_as_datetime(history_max_seq)
+        seq_lag = lag_seconds(history_seq_dt, seq_dt)
+        prev = read_status(CUBIC_ODS_FACT_STATUS, self.table, self.scratch)
+        status: dict[str, MdValues] = {
+            "table": self.table,
+            "last_run": now.isoformat(),
+            "snapshot": self.history_snapshot,
+            "row_count": row_count,
+            "max_header__change_seq": None if max_seq is None else str(max_seq),
+            "max_change_seq_datetime": None if seq_dt is None else seq_dt.isoformat(),
+            "history_max_header__change_seq": (
+                None if history_max_seq is None else str(history_max_seq)
+            ),
+            "history_max_change_seq_datetime": (
+                None if history_seq_dt is None else history_seq_dt.isoformat()
+            ),
+            "seq_lag_seconds": seq_lag,
+            "clock_lag_seconds": lag_seconds(now, seq_dt),
+            "cdc_budget_nearly_full": cdc_budget_nearly_full,
+            "cdc_records_pending": cdc_records_pending,
+            "next_run_seconds": next_run_secs,
+        }
+        status.update(
+            progress_fields(
+                prev=prev,
+                now=now,
+                run_duration_secs=(
+                    None if self._run_started is None else time.perf_counter() - self._run_started
+                ),
+                row_count=row_count,
+                watermark=seq_dt,
+                lag_secs=seq_lag,
+                # A new snapshot reloads the table from scratch, so nothing published
+                # against the previous one is a comparable starting point.
+                comparable=prev is not None and prev.get("snapshot") == self.history_snapshot,
+            )
+        )
+        publish_status(CUBIC_ODS_FACT_STATUS, self.table, self.scratch, status)
+
     def load_cdc_records(self) -> int:
         """
         Load CDC records and apply to fact table.
@@ -394,14 +486,19 @@ class CubicODSFact(OdinJob):
              upload to S3.
         """
         # --- Step 1: Load current fact table state ---
+        self._run_started = time.perf_counter()
         logger = ProcessLog("load_cdc_records", table=self.table)
         fact_ds = ds_from_path(s3_folder(self.s3_export))
         initial_row_count = fact_ds.count_rows()
         _, max_fact_seq = ds_metadata_min_max(fact_ds, "header__change_seq")
         _, max_odin_index = ds_metadata_min_max(fact_ds, "odin_index")
+        # Newest change_seq upstream, for the status file's true-backlog measure. Read from
+        # metadata only, and snapshot_check already walks these fragments, so it is cheap.
+        _, history_max_seq = ds_metadata_min_max(self.history_ds, "header__change_seq")
         logger.add_metadata(
             initial_row_count=initial_row_count,
             max_fact_seq=str(max_fact_seq),
+            history_max_seq=str(history_max_seq),
             max_odin_index=str(max_odin_index),
             cdc_batch_max_nbytes=CDC_BATCH_MAX_NBYTES,
             cdc_accumulation_max_nbytes=CDC_ACCUMULATION_MAX_NBYTES,
@@ -420,7 +517,16 @@ class CubicODSFact(OdinJob):
 
         if not all_cdc_frames:
             logger.complete(cdc_records_found=0, cdc_accumulated_nbytes=0)
-            return _long_run_interval()
+            next_run_secs = _long_run_interval()
+            self.write_status(
+                max_seq=max_fact_seq,
+                history_max_seq=history_max_seq,
+                row_count=initial_row_count,
+                cdc_budget_nearly_full=False,
+                cdc_records_pending=0,
+                next_run_secs=next_run_secs,
+            )
+            return next_run_secs
 
         cdc_df = pl.concat(all_cdc_frames, how="diagonal")
         del all_cdc_frames
@@ -622,8 +728,20 @@ class CubicODSFact(OdinJob):
         )
 
         if cdc_budget_nearly_full and ds_available_count > 0:
-            return NEXT_RUN_IMMEDIATE
-        return _default_run_interval()
+            next_run_secs = NEXT_RUN_IMMEDIATE
+        else:
+            next_run_secs = _default_run_interval()
+
+        self.write_status(
+            max_seq=verify_max,
+            history_max_seq=history_max_seq,
+            row_count=final_row_count,
+            cdc_budget_nearly_full=cdc_budget_nearly_full,
+            cdc_records_pending=ds_available_count,
+            next_run_secs=next_run_secs,
+        )
+
+        return next_run_secs
 
     def run(self) -> int:
         """

--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -15,8 +15,14 @@ from odin.job import OdinJob
 from odin.job import job_proc_schedule
 from odin.utils.runtime import sigterm_check
 from odin.utils.runtime import disk_free_pct
+from odin.utils.logger import MdValues
 from odin.utils.logger import ProcessLog
+from odin.utils.status import progress_fields
+from odin.utils.status import publish_status
+from odin.utils.status import read_status
+from odin.utils.status import utc_now
 from odin.utils.locations import AFC_DATA
+from odin.utils.locations import AFC_STATUS
 from odin.utils.locations import DATA_SPRINGBOARD
 from odin.utils.aws.s3 import list_objects, s3_folder
 from odin.utils.aws.s3 import download_object
@@ -64,6 +70,10 @@ if os.getenv("ECS_TASK_GROUP", "").startswith("family:odin-prod"):
     )
 
 REQUEST_RETRIES = 3
+
+# Page size requested from the /count endpoint. Also caps how much backlog the status
+# file can see in one call: a table more than this many jobs behind reports a floor.
+API_COUNT_LIMIT = 10_000
 
 APICounts = list[dict[Literal["jobId", "dataCount"], int]]
 
@@ -188,6 +198,16 @@ class ArchiveAFCAPI(OdinJob):
         self.start_kwargs = {"table": table}
         self.export_folder = os.path.join(DATA_SPRINGBOARD, AFC_DATA, table)
         self.pii_drop_columns: list[str] = []
+        # Backlog recorded by re_run_check, published by _write_status. The defaults
+        # are the caught-up answer: re_run_check only queries /count when this run
+        # downloaded something, and downloading nothing means nothing was available.
+        self.jobs_lag = 0
+        self.rows_lag = 0
+        self.api_latest_job_id: int | None = None
+        self.lag_truncated = False
+        self.post_snapshot: AFCParquetSnapshot | None = None
+        # Set by run(); the denominator for the status file's rates.
+        self._run_started: float | None = None
         self.headers = {
             "client_id": os.getenv("AFC_API_CLIENT_ID", ""),
             "client_secret": os.getenv("AFC_API_CLIENT_SECRET", ""),
@@ -421,7 +441,7 @@ class ArchiveAFCAPI(OdinJob):
         :return: sorted list of APICounts
         """
         count_url = f"{API_ROOT}/count"
-        req_fields = {"table_name": self.table, "limit": str(10_000)}
+        req_fields = {"table_name": self.table, "limit": str(API_COUNT_LIMIT)}
         while True:
             req_fields["jobIdFrom"] = str(job_id_from)
             try:
@@ -615,6 +635,8 @@ class ArchiveAFCAPI(OdinJob):
             upload_file(new_path, move_path)
         post_snapshot = self._s3_parquet_snapshot()
         self._log_inline_health_metrics(pre_snapshot, post_snapshot)
+        # Ground truth for the status file: what actually landed in S3 this run.
+        self.post_snapshot = post_snapshot
         log.complete()
 
     def re_run_check(self) -> int:
@@ -622,25 +644,109 @@ class ArchiveAFCAPI(OdinJob):
         Determine when job should be re-run.
 
         If `count` returning more than 1 job, based on self.max_job_id, more jobs available.
+
+        Also records the outstanding backlog for the status file. job_id values are not
+        contiguous (e.g. 2000 can follow 1000), so lag is only meaningful as a total
+        across the jobs actually listed: /count returns a dataCount per job, giving
+        both the number of jobs and the number of rows still to ingest. This reuses
+        the response already fetched here, so it costs no extra request.
         """
         log = ProcessLog("re_run_check", table=self.table, max_job_id=self.max_job_id)
         return_duration = NEXT_RUN_BETA if _ODIN_INSTANCE == "beta" else NEXT_RUN_DEFAULT
         if self.max_job_id > 0:
             r = self.make_request(
                 url=f"{API_ROOT}/count",
-                fields={"table_name": self.table, "jobIdFrom": str(self.max_job_id)},
+                fields={
+                    "table_name": self.table,
+                    "jobIdFrom": str(self.max_job_id),
+                    # Without an explicit limit the endpoint applies its own default,
+                    # which would silently truncate the backlog totals below. Matches
+                    # the limit api_job_ids pages with.
+                    "limit": str(API_COUNT_LIMIT),
+                },
             )
             remaining_jobs: APICounts = r.json()
             remaining_count = len(remaining_jobs)
             if remaining_count > 1:
                 return_duration = 60 * 5
             api_latest_job_id = max((j["jobId"] for j in remaining_jobs), default=0)
+            # /count is currently inclusive of jobIdFrom, so the already-ingested job at
+            # max_job_id comes back in this list; counting it would overstate the backlog
+            # by a whole job's rows. Filter as api_job_ids does, which is correct whether
+            # the endpoint is inclusive or exclusive.
+            pending = [j for j in remaining_jobs if j["jobId"] > self.max_job_id]
+            self.jobs_lag = len(pending)
+            self.rows_lag = sum(int(j["dataCount"]) for j in pending)
+            self.api_latest_job_id = api_latest_job_id
+            self.lag_truncated = remaining_count >= API_COUNT_LIMIT
             log.add_metadata(
                 remaining_job_count=remaining_count,
                 api_latest_job_id=api_latest_job_id,
+                jobs_lag=self.jobs_lag,
+                rows_lag=self.rows_lag,
             )
         log.complete(return_duration=return_duration)
         return return_duration
+
+    def _write_status(self, next_run_secs: int) -> None:
+        """
+        Publish this table's ingestion status to S3 as JSON.
+
+        The backlog here is a count of pending work, not a span of time: job_id carries
+        no timestamp, and the values are not contiguous, so "how many job_ids behind"
+        would be meaningless as an arithmetic gap. ``jobs_lag`` and ``rows_lag`` instead
+        total the jobs and their dataCount rows that /count still lists past the
+        watermark -- both taken from the response re_run_check already fetched.
+
+        There is deliberately no lag in seconds: nothing in this API exposes an event
+        time to measure freshness against, so publishing one would be an invention.
+
+        The catch-up estimate is therefore built from rows rather than event time --
+        ``rows_lag`` divided by this run's rows/sec. Unlike the CDC jobs there is no
+        wall-clock variant, for the same reason: with no event time there is no frontier
+        to measure against, so how fast the source is producing new rows is unknowable
+        from here. ``catchup_processing_seconds`` is compute remaining, not time of day.
+
+        Status is best-effort: publish_status swallows its own failures.
+
+        :param next_run_secs: seconds until this table's next scheduled run
+        """
+        now = utc_now()
+        snapshot = self.post_snapshot or self._s3_parquet_snapshot()
+        row_count = snapshot["total_rows"]
+        prev = read_status(AFC_STATUS, self.table, self.scratch)
+        status: dict[str, MdValues] = {
+            "table": self.table,
+            "table_type": getattr(self, "table_type", None),
+            "last_run": now.isoformat(),
+            "row_count": row_count,
+            "object_count": snapshot["object_count"],
+            "total_size_bytes": snapshot["total_size_bytes"],
+            "max_job_id": snapshot["max_job_id"],
+            "api_latest_job_id": self.api_latest_job_id,
+            "jobs_lag": self.jobs_lag,
+            "rows_lag": self.rows_lag,
+            "lag_truncated": self.lag_truncated,
+            "next_run_seconds": next_run_secs,
+        }
+        # No watermark/lag_secs: this job has no event time, so only the row-rate half
+        # of progress_fields applies.
+        progress = progress_fields(
+            prev=prev,
+            now=now,
+            run_duration_secs=(
+                None if self._run_started is None else time.perf_counter() - self._run_started
+            ),
+            row_count=row_count,
+            comparable=prev is not None,
+        )
+        rows_per_second = progress.get("rows_per_second")
+        if isinstance(rows_per_second, (int, float)) and rows_per_second > 0:
+            progress["catchup_processing_seconds"] = int(self.rows_lag / rows_per_second)
+        elif self.rows_lag == 0:
+            progress["catchup_processing_seconds"] = 0
+        status.update(progress)
+        publish_status(AFC_STATUS, self.table, self.scratch, status)
 
     def run(self) -> int:
         """
@@ -660,6 +766,7 @@ class ArchiveAFCAPI(OdinJob):
         June 2, 2025 - Updated to handle "static" and "transactional" table types.
         """
         self.start_kwargs = {"table": self.table}
+        self._run_started = time.perf_counter()
         # Current timetout set to 10 mins, for full PROD deployment should be no more than 2 mins.
         self.req_pool = urllib3.PoolManager(
             headers=self.headers,
@@ -670,6 +777,7 @@ class ArchiveAFCAPI(OdinJob):
         self.load_job_ids()
         next_run_duration = self.re_run_check()
         self.sync_parquet()
+        self._write_status(next_run_duration)
         return next_run_duration
 
 

--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -645,11 +645,8 @@ class ArchiveAFCAPI(OdinJob):
 
         If `count` returning more than 1 job, based on self.max_job_id, more jobs available.
 
-        Also records the outstanding backlog for the status file. job_id values are not
-        contiguous (e.g. 2000 can follow 1000), so lag is only meaningful as a total
-        across the jobs actually listed: /count returns a dataCount per job, giving
-        both the number of jobs and the number of rows still to ingest. This reuses
-        the response already fetched here, so it costs no extra request.
+        Also records the outstanding backlog for the status file; /count returns a dataCount
+        per job, giving both the number of jobs and the number of rows still to ingest.
         """
         log = ProcessLog("re_run_check", table=self.table, max_job_id=self.max_job_id)
         return_duration = NEXT_RUN_BETA if _ODIN_INSTANCE == "beta" else NEXT_RUN_DEFAULT
@@ -659,9 +656,6 @@ class ArchiveAFCAPI(OdinJob):
                 fields={
                     "table_name": self.table,
                     "jobIdFrom": str(self.max_job_id),
-                    # Without an explicit limit the endpoint applies its own default,
-                    # which would silently truncate the backlog totals below. Matches
-                    # the limit api_job_ids pages with.
                     "limit": str(API_COUNT_LIMIT),
                 },
             )
@@ -670,10 +664,8 @@ class ArchiveAFCAPI(OdinJob):
             if remaining_count > 1:
                 return_duration = 60 * 5
             api_latest_job_id = max((j["jobId"] for j in remaining_jobs), default=0)
-            # /count is currently inclusive of jobIdFrom, so the already-ingested job at
+            # /count is inclusive of jobIdFrom, so the already-ingested job at
             # max_job_id comes back in this list; counting it would overstate the backlog
-            # by a whole job's rows. Filter as api_job_ids does, which is correct whether
-            # the endpoint is inclusive or exclusive.
             pending = [j for j in remaining_jobs if j["jobId"] > self.max_job_id]
             self.jobs_lag = len(pending)
             self.rows_lag = sum(int(j["dataCount"]) for j in pending)

--- a/src/odin/ingestion/afc/afc_archive.py
+++ b/src/odin/ingestion/afc/afc_archive.py
@@ -692,21 +692,6 @@ class ArchiveAFCAPI(OdinJob):
         """
         Publish this table's ingestion status to S3 as JSON.
 
-        The backlog here is a count of pending work, not a span of time: job_id carries
-        no timestamp, and the values are not contiguous, so "how many job_ids behind"
-        would be meaningless as an arithmetic gap. ``jobs_lag`` and ``rows_lag`` instead
-        total the jobs and their dataCount rows that /count still lists past the
-        watermark -- both taken from the response re_run_check already fetched.
-
-        There is deliberately no lag in seconds: nothing in this API exposes an event
-        time to measure freshness against, so publishing one would be an invention.
-
-        The catch-up estimate is therefore built from rows rather than event time --
-        ``rows_lag`` divided by this run's rows/sec. Unlike the CDC jobs there is no
-        wall-clock variant, for the same reason: with no event time there is no frontier
-        to measure against, so how fast the source is producing new rows is unknowable
-        from here. ``catchup_processing_seconds`` is compute remaining, not time of day.
-
         Status is best-effort: publish_status swallows its own failures.
 
         :param next_run_secs: seconds until this table's next scheduled run

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -803,19 +803,6 @@ class ArchiveMasabi(OdinJob):
         """
         Publish this table's freshness status to S3 as JSON.
 
-        Only a clock lag is available here, unlike the Qlik CDC jobs. The API is
-        queried right up to ``now`` each run, so there is no separate upstream
-        watermark to measure against -- "how far behind the source" and "how old the
-        data is" are the same number. The quiet-vs-behind distinction survives as
-        ``caught_up``: a run drains ``(from_ts, now]``, so unless it stopped early at
-        MAXIMUM_ROWS_PER_RUN it has provably consumed everything the API held, however
-        old its newest record is. ``caught_up`` false is therefore this job's "cannot
-        keep up with the volume" signal, the counterpart to the CDC jobs' budget flags.
-
-        The watermark is re-read from parquet rather than taken from the fetched rows,
-        because sync_parquet drops rows at the boundary timestamp -- so the published
-        value is the true resume point the next run will use as from_ts.
-
         Status is best-effort: failures degrade or are swallowed, never failing a run.
 
         :param ts_key: timestamp column this table is ordered/resumed by

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -10,9 +10,17 @@ import yaml
 import polars as pl
 import pyarrow.parquet as pq
 
+from odin.utils.logger import MdValues
 from odin.utils.logger import ProcessLog
+from odin.utils.status import lag_seconds
+from odin.utils.status import ms_as_datetime
+from odin.utils.status import progress_fields
+from odin.utils.status import publish_status
+from odin.utils.status import read_status
+from odin.utils.status import utc_now
 from odin.job import OdinJob, job_proc_schedule
 from odin.utils.locations import DATA_SPRINGBOARD, MASABI_DATA, MASABI_RESTRICTED, MASABI_BACKFILL
+from odin.utils.locations import MASABI_STATUS
 from odin.utils.aws.s3 import s3_folder
 from odin.utils.aws.s3 import download_object
 from odin.utils.aws.s3 import list_objects
@@ -487,12 +495,23 @@ class ArchiveMasabi(OdinJob):
         self.table = table
         self.restricted = restricted
         self.start_kwargs = {"table": table, "restricted": restricted}
+        # Pre-run state, filled in by setup_job and read back by _write_status.
+        self.existing_rows = 0
+        self.existing_max_ts: int | None = None
+        # Set by run(); the denominator for the status file's rates.
+        self._run_started: float | None = None
+        # The status key mirrors the export_folder branching below: the restricted and
+        # gamma/backfill variants archive the same table name to a different prefix, so
+        # keying status on the table alone would have them overwrite each other.
         if restricted:
             self.export_folder = s3_folder(os.path.join(DATA_SPRINGBOARD, MASABI_RESTRICTED, table))
+            self.status_key = f"{table}__restricted"
         elif _ODIN_INSTANCE == "gamma":
             self.export_folder = s3_folder(os.path.join(DATA_SPRINGBOARD, MASABI_BACKFILL, table))
+            self.status_key = f"{table}__backfill"
         else:
             self.export_folder = s3_folder(os.path.join(DATA_SPRINGBOARD, MASABI_DATA, table))
+            self.status_key = table
         self._last_request_time: float = 0.0
 
     def _make_request_pool(self) -> urllib3.PoolManager:
@@ -761,19 +780,106 @@ class ArchiveMasabi(OdinJob):
         )
         existing_ds = ds_from_path(self.export_folder)
         existing_ds_rows = existing_ds.count_rows()
+        # Starting state, reused by _write_status when a run fetches nothing. Kept
+        # distinct from from_ts, which falls back to a configured start constant on an
+        # empty table and so is not a real watermark.
+        self.existing_rows = existing_ds_rows
         if existing_ds_rows:
             _, max_ts = ds_metadata_min_max(existing_ds, ts_key)
             if max_ts is not None:
                 from_ts = int(max_ts)
+                self.existing_max_ts = int(max_ts)
 
         log.complete(from_ts=from_ts, existing_ds_size=existing_ds_rows)
         return from_ts
+
+    def _write_status(
+        self,
+        ts_key: str,
+        wrote_data: bool,
+        hit_row_limit: bool,
+        next_run_secs: int,
+    ) -> None:
+        """
+        Publish this table's freshness status to S3 as JSON.
+
+        Only a clock lag is available here, unlike the Qlik CDC jobs. The API is
+        queried right up to ``now`` each run, so there is no separate upstream
+        watermark to measure against -- "how far behind the source" and "how old the
+        data is" are the same number. The quiet-vs-behind distinction survives as
+        ``caught_up``: a run drains ``(from_ts, now]``, so unless it stopped early at
+        MAXIMUM_ROWS_PER_RUN it has provably consumed everything the API held, however
+        old its newest record is. ``caught_up`` false is therefore this job's "cannot
+        keep up with the volume" signal, the counterpart to the CDC jobs' budget flags.
+
+        The watermark is re-read from parquet rather than taken from the fetched rows,
+        because sync_parquet drops rows at the boundary timestamp -- so the published
+        value is the true resume point the next run will use as from_ts.
+
+        Status is best-effort: failures degrade or are swallowed, never failing a run.
+
+        :param ts_key: timestamp column this table is ordered/resumed by
+        :param wrote_data: whether this run wrote new rows to parquet
+        :param hit_row_limit: run stopped at MAXIMUM_ROWS_PER_RUN with more available
+        :param next_run_secs: seconds until this table's next scheduled run
+        """
+        now = utc_now()
+        max_ts = self.existing_max_ts
+        row_count = self.existing_rows
+        if wrote_data:
+            try:
+                ds = ds_from_path(self.export_folder)
+                row_count = ds.count_rows()
+                _, new_max_ts = ds_metadata_min_max(ds, ts_key)
+                max_ts = None if new_max_ts is None else int(new_max_ts)
+            except Exception as exception:
+                # Fall back to the pre-run values rather than fail an archived run.
+                ProcessLog("masabi_status_reread", table=self.table).failed(exception)
+
+        max_ts_dt = ms_as_datetime(max_ts)
+        clock_lag = lag_seconds(now, max_ts_dt)
+        prev = read_status(MASABI_STATUS, self.status_key, self.scratch)
+        status: dict[str, MdValues] = {
+            "table": self.table,
+            "restricted": self.restricted,
+            "export_folder": self.export_folder,
+            "last_run": now.isoformat(),
+            "row_count": row_count,
+            "timestamp_column": ts_key,
+            "max_timestamp_ms": max_ts,
+            "max_timestamp_datetime": None if max_ts_dt is None else max_ts_dt.isoformat(),
+            "clock_lag_seconds": clock_lag,
+            "caught_up": not hit_row_limit,
+            "next_run_seconds": next_run_secs,
+        }
+        status.update(
+            progress_fields(
+                prev=prev,
+                now=now,
+                run_duration_secs=(
+                    None if self._run_started is None else time.perf_counter() - self._run_started
+                ),
+                row_count=row_count,
+                watermark=max_ts_dt,
+                # Clock lag is the only backlog measure this API affords, so it is what
+                # the catch-up estimate has to run on. It reads as a real backlog only
+                # while the table is behind; once caught_up, the remaining lag is however
+                # quiet the source is, not work left to do, and the estimate says so by
+                # never gaining on it.
+                lag_secs=clock_lag,
+                # The timestamp column decides what the watermark means; an override
+                # change would difference two different clocks.
+                comparable=prev is not None and prev.get("timestamp_column") == ts_key,
+            )
+        )
+        publish_status(MASABI_STATUS, self.status_key, self.scratch, status)
 
     def run(self) -> int:
         """Execute the Masabi archive run loop."""
         global TABLE_SCHEMAS
         global TABLE_JSON_COLS
 
+        self._run_started = time.perf_counter()
         log = ProcessLog(process="masabi_run")
 
         pool = self._make_request_pool()
@@ -807,11 +913,19 @@ class ArchiveMasabi(OdinJob):
             self.sync_parquet(ndjson_path, ts_key)
 
         if hit_row_limit:
+            next_run_secs = NEXT_RUN_IMMEDIATE
             log.complete(next_run_interval="short")
-            return NEXT_RUN_IMMEDIATE
         else:
+            next_run_secs = NEXT_RUN_BETA if _ODIN_INSTANCE == "beta" else NEXT_RUN_DEFAULT
             log.complete(next_run_interval="normal")
-            return NEXT_RUN_BETA if _ODIN_INSTANCE == "beta" else NEXT_RUN_DEFAULT
+
+        self._write_status(
+            ts_key=ts_key,
+            wrote_data=ndjson_path is not None,
+            hit_row_limit=hit_row_limit,
+            next_run_secs=next_run_secs,
+        )
+        return next_run_secs
 
 
 def schedule_masabi_archive(schedule: sched.scheduler) -> None:

--- a/src/odin/ingestion/masabi/masabi_archive.py
+++ b/src/odin/ingestion/masabi/masabi_archive.py
@@ -495,14 +495,11 @@ class ArchiveMasabi(OdinJob):
         self.table = table
         self.restricted = restricted
         self.start_kwargs = {"table": table, "restricted": restricted}
-        # Pre-run state, filled in by setup_job and read back by _write_status.
+
         self.existing_rows = 0
         self.existing_max_ts: int | None = None
-        # Set by run(); the denominator for the status file's rates.
         self._run_started: float | None = None
-        # The status key mirrors the export_folder branching below: the restricted and
-        # gamma/backfill variants archive the same table name to a different prefix, so
-        # keying status on the table alone would have them overwrite each other.
+
         if restricted:
             self.export_folder = s3_folder(os.path.join(DATA_SPRINGBOARD, MASABI_RESTRICTED, table))
             self.status_key = f"{table}__restricted"
@@ -780,9 +777,7 @@ class ArchiveMasabi(OdinJob):
         )
         existing_ds = ds_from_path(self.export_folder)
         existing_ds_rows = existing_ds.count_rows()
-        # Starting state, reused by _write_status when a run fetches nothing. Kept
-        # distinct from from_ts, which falls back to a configured start constant on an
-        # empty table and so is not a real watermark.
+
         self.existing_rows = existing_ds_rows
         if existing_ds_rows:
             _, max_ts = ds_metadata_min_max(existing_ds, ts_key)

--- a/src/odin/ingestion/qlik/utils.py
+++ b/src/odin/ingestion/qlik/utils.py
@@ -2,6 +2,7 @@ import os
 import re
 import shutil
 import tempfile
+from typing import Any
 from typing import List
 from typing import Tuple
 from datetime import datetime
@@ -29,6 +30,26 @@ from odin.utils.parquet import ds_column_min_max
 SNAPSHOT_FMT = "%Y%m%dT%H%M%SZ"
 RE_SNAPSHOT_TS = re.compile(r"(\d{8}T\d{6}Z)")
 RE_CDC_TS = re.compile(r"(\d{8}-\d{9})")
+CHANGE_SEQ_FMT = "%Y%m%d%H%M%S"
+
+
+def seq_as_datetime(seq: Any) -> datetime | None:
+    """
+    Convert a Qlik ``header__change_seq`` to the UTC datetime it encodes.
+
+    A change_seq leads with its event time as ``%Y%m%d%H%M%S`` followed by
+    padding, e.g. ``20260619214440000...`` -> 2026-06-19 21:44:40 UTC.
+
+    :param seq: header__change_seq value (may be None or non-conforming)
+
+    :return: event time as UTC datetime, or None if `seq` can't be parsed
+    """
+    if seq is None:
+        return None
+    try:
+        return datetime.strptime(str(seq)[:14], CHANGE_SEQ_FMT).replace(tzinfo=UTC)
+    except ValueError:
+        return None
 
 
 class RecentSnapshotError(Exception):

--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -64,6 +64,16 @@ class OdinJob(ABC):
 
     start_kwargs: Dict[str, MdValues] = {}
 
+    @property
+    def scratch(self) -> str:
+        """
+        Return a directory safe to stage files in.
+
+        start() provides tmpdir for real runs; direct step calls (tests) fall back to
+        the system temp folder rather than raising.
+        """
+        return getattr(self, "tmpdir", None) or tempfile.gettempdir()
+
     def reset_tmpdir(self) -> None:
         """Reset TemporaryDirectory folder."""
         if hasattr(self, "_tdir"):

--- a/src/odin/utils/locations.py
+++ b/src/odin/utils/locations.py
@@ -10,6 +10,7 @@ DATA_SPRINGBOARD = os.getenv("DATA_SPRINGBOARD", "unset_DATA_SPRINGBOARD")
 ODIN_DATA = "odin/data"
 ODIN_ARCHIVE = "odin/archive"
 ODIN_ERROR = "odin/error"
+ODIN_LOGS = "odin/logs"
 ODIN_MIGRATIONS = "odin/migrations"
 ODIN_DICTIONARY = f"{ODIN_DATA}/dictionary"
 
@@ -24,11 +25,16 @@ CUBIC_QLIK_IGNORED = f"{ODIN_ARCHIVE}/cubic_qlik/ignored"
 CUBIC_ODS_FACT_DATA = f"{ODIN_DATA}/cubic/ods"
 CUBIC_ODS_REPORTS = f"{ODIN_DATA}/cubic/reports"
 
+# Per-table fact status JSON, published for anyone with read access to the bucket
+CUBIC_ODS_FACT_STATUS = f"{ODIN_LOGS}/ods"
+
 CUBIC_ODS_DELTA_DATA = f"{ODIN_DATA}/cubic/ods_delta"
+CUBIC_ODS_DELTA_STATUS = f"{ODIN_LOGS}/ods_delta"
 
 # AFC
 AFC_DATA = f"{ODIN_DATA}/sb/api"
 AFC_RESTRICTED = f"{ODIN_DATA}/sb/restricted"
+AFC_STATUS = f"{ODIN_LOGS}/afc"
 
 # Masabi
 MASABI_DATA = f"{ODIN_DATA}/masabi/api"
@@ -37,3 +43,4 @@ MASABI_TEMP = f"{ODIN_DATA}/masabi/temporary"
 # Destination for the historical backfill job. Kept separate from MASABI_DATA
 # so the live pipeline is undisturbed until the backfill is swapped in.
 MASABI_BACKFILL = f"{ODIN_DATA}/masabi/backfill"
+MASABI_STATUS = f"{ODIN_LOGS}/masabi"

--- a/src/odin/utils/status.py
+++ b/src/odin/utils/status.py
@@ -1,0 +1,279 @@
+"""
+Publish per-job status JSON to S3 for external monitoring.
+
+Odin jobs answer "am I keeping up?" with data they already hold mid-run. Each job
+writes that answer to one small JSON object per table under a status prefix, so
+anyone with read access to the bucket can check freshness without scraping logs or
+re-deriving it from dataset metadata.
+
+Payload shape is deliberately per-job rather than one shared schema: a CDC job's
+backlog is a span of time, an API job's is a count of pending work, and forcing
+those into common field names would misrepresent both. What is shared is the
+plumbing here -- serialize, upload, never fail the caller.
+"""
+
+import json
+import os
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from odin.utils.aws.s3 import download_object
+from odin.utils.aws.s3 import upload_file
+from odin.utils.locations import DATA_SPRINGBOARD
+from odin.utils.logger import MdValues
+from odin.utils.logger import ProcessLog
+
+SECONDS_PER_DAY = 60 * 60 * 24
+SECONDS_PER_HOUR = 60 * 60
+
+
+def utc_now() -> datetime:
+    """Return the current time as an aware UTC datetime."""
+    return datetime.now(timezone.utc)
+
+
+def ms_as_datetime(epoch_ms: int | float | None) -> datetime | None:
+    """
+    Convert milliseconds since the UTC epoch to an aware UTC datetime.
+
+    :param epoch_ms: ms since epoch (may be None or out of range)
+
+    :return: UTC datetime, or None if `epoch_ms` is missing or not convertible
+    """
+    if epoch_ms is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(epoch_ms) / 1000, tz=timezone.utc)
+    except (ValueError, OverflowError, OSError):
+        return None
+
+
+def lag_seconds(newer: datetime | None, older: datetime | None) -> int | None:
+    """
+    Return whole seconds between two datetimes, or None if either is unknown.
+
+    Not clamped: a negative result means `older` is ahead of `newer`, which is worth
+    surfacing rather than hiding behind a floor of zero.
+
+    :param newer: the later reference point
+    :param older: the earlier reference point
+
+    :return: int seconds, or None
+    """
+    if newer is None or older is None:
+        return None
+    return int((newer - older).total_seconds())
+
+
+def iso_as_datetime(value: MdValues) -> datetime | None:
+    """
+    Parse an ISO-8601 string from a previous status payload back to a datetime.
+
+    :param value: value read from JSON (may be missing, None, or malformed)
+
+    :return: aware UTC datetime, or None if not parseable
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def read_status(status_prefix: str, key: str, tmpdir: str) -> dict[str, MdValues] | None:
+    """
+    Read the status object a previous run published, if there is one.
+
+    This is what makes run-over-run rates possible: each object carries the fields the
+    next run differences against, so no separate history store is needed. One small GET
+    per run.
+
+    Best-effort by contract, and a miss is normal rather than exceptional -- the first
+    run of a table has no predecessor. Any failure returns None, which callers render
+    as absent rates rather than a failed run.
+
+    :param status_prefix: bucket-relative status folder, e.g. CUBIC_ODS_FACT_STATUS
+    :param key: object stem, typically the table name (no .json suffix)
+    :param tmpdir: job scratch directory to stage the download in
+
+    :return: the previous payload, or None if absent/unreadable
+    """
+    log = ProcessLog("read_status", status_prefix=status_prefix, key=key)
+    try:
+        local_path = os.path.join(tmpdir, "previous_status.json")
+        downloaded = download_object(
+            os.path.join(DATA_SPRINGBOARD, status_prefix, f"{key}.json"), local_path
+        )
+        if not downloaded:
+            log.complete(found=False)
+            return None
+        with open(local_path) as status_file:
+            payload = json.load(status_file)
+        if not isinstance(payload, dict):
+            log.complete(found=False)
+            return None
+        log.complete(found=True)
+        return payload
+
+    except Exception as exception:
+        log.failed(exception)
+        return None
+
+
+def _rate_fields(
+    row_count: int | None,
+    prev_row_count: MdValues,
+    run_duration_secs: float | None,
+) -> dict[str, MdValues]:
+    """Row-count delta and rows/sec over this run's processing time."""
+    fields: dict[str, MdValues] = {}
+    if not isinstance(prev_row_count, int) or row_count is None:
+        return fields
+    rows_added = row_count - prev_row_count
+    fields["rows_added"] = rows_added
+    if run_duration_secs and run_duration_secs > 0:
+        fields["rows_per_second"] = round(rows_added / run_duration_secs, 2)
+    return fields
+
+
+def progress_fields(
+    prev: dict[str, MdValues] | None,
+    now: datetime,
+    run_duration_secs: float | None,
+    row_count: int | None = None,
+    watermark: datetime | None = None,
+    lag_secs: int | None = None,
+    comparable: bool = True,
+) -> dict[str, MdValues]:
+    """
+    Compare this run against the previous one: what moved, how fast, and time to catch up.
+
+    Only selected scalars from `prev` are echoed, never the whole payload -- nesting the
+    previous object would make each run's file contain every run before it.
+
+    Two throughput measures, because they answer different questions:
+
+      * ``data_days_per_processing_hour`` -- how much event time the job digests per hour
+        it spends working. A pure throughput figure, independent of how often it is
+        scheduled, and the one to compare across tables.
+      * ``catchup_ratio`` -- watermark advance divided by *wall* time since the last run.
+        Above 1.0 means gaining on the source, below means losing. This is the honest
+        keep-up test, because the upstream frontier keeps moving while the job sleeps
+        between runs.
+
+    Both catch-up estimates are therefore reported:
+
+      * ``catchup_processing_seconds`` -- lag / throughput. Answers "how much compute is
+        left", holding the frontier still. Never None while the job is making progress,
+        and always the smaller (more optimistic) of the two.
+      * ``catchup_wall_seconds`` -- lag / (catchup_ratio - 1), accounting for the frontier
+        advancing one second per second. None when ``catchup_ratio <= 1``, which is not a
+        gap in the data but the finding itself: the table will never catch up on the
+        current schedule, no matter how fast each individual run is.
+
+    Rates are one-cycle deltas, not smoothed averages, so a single unusually large or
+    small batch swings them; they describe the last cycle, not a trend.
+
+    :param prev: previous status payload, or None on a first run
+    :param now: this run's ``last_run`` timestamp
+    :param run_duration_secs: processing seconds this run spent
+    :param row_count: current row count
+    :param watermark: current data-time position (None for jobs without an event time)
+    :param lag_secs: remaining backlog in data-seconds (seq lag, or clock lag)
+    :param comparable: False when the previous run measured something else (e.g. a
+        different snapshot), which makes every delta against it meaningless
+
+    :return: progress fields, empty-ish when there is nothing valid to compare against
+    """
+    fields: dict[str, MdValues] = {
+        "run_duration_seconds": (
+            None if run_duration_secs is None else round(run_duration_secs, 2)
+        ),
+    }
+    if prev is None or not comparable:
+        return fields
+
+    prev_run = iso_as_datetime(prev.get("last_run"))
+    fields["previous_last_run"] = None if prev_run is None else prev_run.isoformat()
+    fields["previous_row_count"] = prev.get("row_count")
+    wall_secs = lag_seconds(now, prev_run)
+    fields["seconds_since_last_run"] = wall_secs
+
+    fields.update(_rate_fields(row_count, prev.get("row_count"), run_duration_secs))
+
+    prev_watermark = iso_as_datetime(
+        prev.get("watermark_datetime")
+        or prev.get("max_change_seq_datetime")
+        or prev.get("max_timestamp_datetime")
+    )
+    advance = lag_seconds(watermark, prev_watermark)
+    if advance is None:
+        return fields
+    fields["watermark_advance_seconds"] = advance
+
+    if run_duration_secs and run_duration_secs > 0:
+        fields["data_days_per_processing_hour"] = round(
+            (advance / SECONDS_PER_DAY) / (run_duration_secs / SECONDS_PER_HOUR), 3
+        )
+    if wall_secs and wall_secs > 0:
+        fields["catchup_ratio"] = round(advance / wall_secs, 3)
+
+    if lag_secs is None:
+        return fields
+    if lag_secs <= 0:
+        fields["catchup_processing_seconds"] = 0
+        fields["catchup_wall_seconds"] = 0
+        fields["projected_caught_up"] = None
+        return fields
+    if advance > 0 and run_duration_secs and run_duration_secs > 0:
+        fields["catchup_processing_seconds"] = int(lag_secs / (advance / run_duration_secs))
+    # Gaining only if the watermark outruns the frontier's one-second-per-second advance.
+    if wall_secs and wall_secs > 0 and advance > wall_secs:
+        wall_remaining = int(lag_secs / ((advance - wall_secs) / wall_secs))
+        fields["catchup_wall_seconds"] = wall_remaining
+        fields["projected_caught_up"] = (now + timedelta(seconds=wall_remaining)).isoformat()
+    else:
+        fields["catchup_wall_seconds"] = None
+        fields["projected_caught_up"] = None
+    return fields
+
+
+def publish_status(
+    status_prefix: str,
+    key: str,
+    tmpdir: str,
+    payload: dict[str, MdValues],
+) -> None:
+    """
+    Publish `payload` to ``s3://<DATA_SPRINGBOARD>/<status_prefix>/<key>.json``.
+
+    Overwrites on every call, so the object always reflects the latest completed run.
+    A single PUT per table keeps writes atomic; jobs run as separate processes, so an
+    aggregate file would need a read-modify-write that could drop tables.
+
+    Best-effort by contract: any failure is logged and swallowed. Status is telemetry
+    and must never fail an otherwise successful job. The consequence is that a stale
+    object means "this job is not finishing", which is itself the signal worth having.
+
+    :param status_prefix: bucket-relative status folder, e.g. CUBIC_ODS_FACT_STATUS
+    :param key: object stem, typically the table name (no .json suffix)
+    :param tmpdir: job scratch directory to stage the file in
+    :param payload: JSON-serializable status fields
+    """
+    log = ProcessLog("publish_status", status_prefix=status_prefix, key=key)
+    try:
+        status_path = os.path.join(tmpdir, "status.json")
+        with open(status_path, "w") as status_file:
+            json.dump(payload, status_file, indent=2)
+        upload_file(
+            status_path,
+            os.path.join(DATA_SPRINGBOARD, status_prefix, f"{key}.json"),
+            extra_args={"ContentType": "application/json"},
+        )
+        log.complete(**payload)
+
+    except Exception as exception:
+        log.failed(exception)

--- a/src/odin/utils/status.py
+++ b/src/odin/utils/status.py
@@ -1,15 +1,10 @@
 """
 Publish per-job status JSON to S3 for external monitoring.
 
-Odin jobs answer "am I keeping up?" with data they already hold mid-run. Each job
-writes that answer to one small JSON object per table under a status prefix, so
-anyone with read access to the bucket can check freshness without scraping logs or
-re-deriving it from dataset metadata.
+Several Odin jobs write their health and freshness status to JSON objects
+on S3 per run. These do are not intended to have a shared schema across job types.
 
-Payload shape is deliberately per-job rather than one shared schema: a CDC job's
-backlog is a span of time, an API job's is a count of pending work, and forcing
-those into common field names would misrepresent both. What is shared is the
-plumbing here -- serialize, upload, never fail the caller.
+Logging should never cause an exception that interrupts the update job itself.
 """
 
 import json
@@ -85,15 +80,7 @@ def iso_as_datetime(value: MdValues) -> datetime | None:
 
 def read_status(status_prefix: str, key: str, tmpdir: str) -> dict[str, MdValues] | None:
     """
-    Read the status object a previous run published, if there is one.
-
-    This is what makes run-over-run rates possible: each object carries the fields the
-    next run differences against, so no separate history store is needed. One small GET
-    per run.
-
-    Best-effort by contract, and a miss is normal rather than exceptional -- the first
-    run of a table has no predecessor. Any failure returns None, which callers render
-    as absent rates rather than a failed run.
+    Read the status object a previous run published, if any, or return None.
 
     :param status_prefix: bucket-relative status folder, e.g. CUBIC_ODS_FACT_STATUS
     :param key: object stem, typically the table name (no .json suffix)
@@ -149,7 +136,7 @@ def progress_fields(
     comparable: bool = True,
 ) -> dict[str, MdValues]:
     """
-    Compare this run against the previous one: what moved, how fast, and time to catch up.
+    Compare this run against the previous one.
 
     Only selected scalars from `prev` are echoed, never the whole payload -- nesting the
     previous object would make each run's file contain every run before it.
@@ -174,8 +161,7 @@ def progress_fields(
         gap in the data but the finding itself: the table will never catch up on the
         current schedule, no matter how fast each individual run is.
 
-    Rates are one-cycle deltas, not smoothed averages, so a single unusually large or
-    small batch swings them; they describe the last cycle, not a trend.
+    Note that all rates are one-cycle deltas, not smoothed averages.
 
     :param prev: previous status payload, or None on a first run
     :param now: this run's ``last_run`` timestamp
@@ -250,13 +236,7 @@ def publish_status(
     """
     Publish `payload` to ``s3://<DATA_SPRINGBOARD>/<status_prefix>/<key>.json``.
 
-    Overwrites on every call, so the object always reflects the latest completed run.
-    A single PUT per table keeps writes atomic; jobs run as separate processes, so an
-    aggregate file would need a read-modify-write that could drop tables.
-
-    Best-effort by contract: any failure is logged and swallowed. Status is telemetry
-    and must never fail an otherwise successful job. The consequence is that a stale
-    object means "this job is not finishing", which is itself the signal worth having.
+    Updates are atomic overwrites of the previous file.
 
     :param status_prefix: bucket-relative status folder, e.g. CUBIC_ODS_FACT_STATUS
     :param key: object stem, typically the table name (no .json suffix)


### PR DESCRIPTION
Users have no good way of determining when data is behind, often noticing only when reports become obviously incomplete. We have a few tools that we can use to dig in and identify problems when they arise (and when we are notified), but each data source works differently, the available metrics from each are different, and each involves some manual effort.

This PR introduces new, lightweight code which logs the status of each table to S3 as a JSON, which is easily inspectable by users (and us as maintainers), and structured for use in scripts. Specifically, it measures if and by how much the user-facing tables lag behind the history, API, and/or clock time, depending on what exact metrics available in that source. These logs exist for ODS tables (current-gen and deltalake based), S&B tables, and Masabi tables.

For example, S&B data tracks data by 'job_id', so a table which is behind might look like this (as measured on dev):

```
{
  "table": "v_shiftevent",
  "table_type": "transactional",
  "last_run": "2026-07-17T19:21:30.388014+00:00",
  "row_count": 3934207,
  "object_count": 1,
  "total_size_bytes": 24222679,
  "max_job_id": 559242,
  "api_latest_job_id": 569252,
  "jobs_lag": 9999,
  "rows_lag": 8261871,
  "lag_truncated": true,
  "next_run_seconds": 300,
  "run_duration_seconds": 25.29,
  "previous_last_run": "2026-07-17T18:02:02.627098+00:00",
  "previous_row_count": 3933049,
  "seconds_since_last_run": 4767,
  "rows_added": 1158,
  "rows_per_second": 45.79,
  "catchup_processing_seconds": 180429
}
```
Here we can see that `v_shiftevent` user-facing table, last run on `2026-07-17T19:21:30`, has `max_job_id` of 559242, which is behind the latest job_id available upstream in the API (`api_latest_job_id: 569252`). The `jobs_lag` measures how many jobs it is behind (capped at 9999, because it only fetched the latest 10000 jobs from the API, which is why `"lag_truncated": true`). These job_ids comprise 8261871 rows of data (`rows_lag`). In this run, `1158` rows were added, over 25.29 seconds, resulting in `rows_per_second": 45.79`, from which we can infer this table needs 180429 seconds of additional processing time (~50 hours).

ODS tables (of either type) track change data with `header__change_seq`, which contains the datetime that the change was generated by Qlik. This allows us to compare in terms of calendar time how behind each table is both in reference to our compiled history and to the upstream data generation. The ODS logs also contain information about the snapshot date and total rows, to assess how long it would take to catch back up if the table needed to be reset.

Masabi similarly records the date (in Unix time) that data was created on its server, which can be compared to the clock time.

The time added to each of these jobs to collect the data and write out the logs should be negligible. 
