### PR TITLE
Retry faster on -11 flags (SIGSEGV errors)

### DIFF
--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -18,6 +18,7 @@ from odin.utils.logger import MdValues
 from odin.utils.runtime import sigterm_check
 
 NEXT_RUN_DEFAULT = 60 * 60 * 6  # 6 hours
+NEXT_RUN_OOM = 60 * 60 * 1  # 1 hour
 NEXT_RUN_FAILED = 60 * 60 * 24  # 24 hours
 
 # How often the parent samples a running job subprocess' memory and disk spill, in seconds
@@ -253,7 +254,10 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler | None) -> None:
             **job.start_kwargs,
         )
         fail_log.failed(SystemError("OdinJob killed by ECS."))
-        proc_return_val.value = NEXT_RUN_FAILED
+        if proc.exitcode == -11:
+            proc_return_val.value = NEXT_RUN_OOM
+        else:
+            proc_return_val.value = NEXT_RUN_FAILED
 
     if schedule is not None:
         schedule.enter(proc_return_val.value, 1, job_proc_schedule, (job, schedule))

--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -18,7 +18,7 @@ from odin.utils.logger import MdValues
 from odin.utils.runtime import sigterm_check
 
 NEXT_RUN_DEFAULT = 60 * 60 * 6  # 6 hours
-NEXT_RUN_OOM = 60 * 5  # 10 minutes
+NEXT_RUN_SIGSEGV = 60 * 5  # 5 minutes
 NEXT_RUN_FAILED = 60 * 60 * 24  # 24 hours
 
 # How often the parent samples a running job subprocess' memory and disk spill, in seconds
@@ -255,7 +255,7 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler | None) -> None:
         )
         fail_log.failed(SystemError("OdinJob killed by ECS."))
         if proc.exitcode == -11:
-            proc_return_val.value = NEXT_RUN_OOM
+            proc_return_val.value = NEXT_RUN_SIGSEGV
         else:
             proc_return_val.value = NEXT_RUN_FAILED
 

--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -18,7 +18,7 @@ from odin.utils.logger import MdValues
 from odin.utils.runtime import sigterm_check
 
 NEXT_RUN_DEFAULT = 60 * 60 * 6  # 6 hours
-NEXT_RUN_OOM = 60 * 60 * 1  # 1 hour
+NEXT_RUN_OOM = 60 * 5  # 10 minutes
 NEXT_RUN_FAILED = 60 * 60 * 24  # 24 hours
 
 # How often the parent samples a running job subprocess' memory and disk spill, in seconds


### PR DESCRIPTION
Currently, all uncaught exceptions are retryed at OdinJob's default NEXT_RUN_FAILED delay, which is a full 24 hours. This makes sense when the issue e.g. vendor-side API issues, but less sense when the issue is sporadic runtime errors such as OOM hits. This catches the SIGSEGV error code and uses a shorter retry delay.