### PR TITLE
chore: decrease delta NEXT_RUN_IMMEDIATE to 30 seconds

### DIFF
--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -98,7 +98,7 @@ from odin.ingestion.qlik.tables import CUBIC_ODS_DELTA_TABLES_INSTANCE
 
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
 NEXT_RUN_BETA = 60 * 15  # 15 minutes
-NEXT_RUN_IMMEDIATE = 60 * 5  # 5 minutes
+NEXT_RUN_IMMEDIATE = 60 * 1  # 1 minute
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
 REBUILD_BATCH_SIZE = 10_000

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -98,7 +98,7 @@ from odin.ingestion.qlik.tables import CUBIC_ODS_DELTA_TABLES_INSTANCE
 
 NEXT_RUN_DEFAULT = 60 * 60 * 4  # 4 hours
 NEXT_RUN_BETA = 60 * 15  # 15 minutes
-NEXT_RUN_IMMEDIATE = 60 * 1  # 1 minute
+NEXT_RUN_IMMEDIATE = 30  # 30 seconds
 NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
 REBUILD_BATCH_SIZE = 10_000


### PR DESCRIPTION
Right now the only running delta job is on its own instance, and is running for 2-4 minutes each run. Since the job scheduler is strictly non-parallel, setting NEXT_RUN_IMMEDIATE at 5 resulted in ~60% of time spent idle