### PR TITLE
Pin duckdb==1.5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 dependencies = [
     "boto3",
     "deltalake>=1.5",
-    "duckdb",
+    "duckdb==1.5.4",
     "polars>=1.34",
     "psutil",
     "pyarrow",


### PR DESCRIPTION
Pins duckdb to version 1.5.4 (was previously 1.4.4 on prod) in case this fixes a series of invalid allocations and segfaults that appear to be coming from duckdb operations in delta_ods.