### PR TITLE
fix: temporarily restart faster on OOM

### DIFF
--- a/src/odin/job.py
+++ b/src/odin/job.py
@@ -19,6 +19,7 @@ from odin.utils.runtime import sigterm_check
 
 NEXT_RUN_DEFAULT = 60 * 60 * 6  # 6 hours
 NEXT_RUN_SIGSEGV = 60 * 5  # 5 minutes
+NEXT_RUN_SIGKILL = 60 * 5  # 5 minutes
 NEXT_RUN_FAILED = 60 * 60 * 24  # 24 hours
 
 # How often the parent samples a running job subprocess' memory and disk spill, in seconds
@@ -266,6 +267,8 @@ def job_proc_schedule(job: OdinJob, schedule: sched.scheduler | None) -> None:
         fail_log.failed(SystemError("OdinJob killed by ECS."))
         if proc.exitcode == -11:
             proc_return_val.value = NEXT_RUN_SIGSEGV
+        elif proc.exitcode == -9:
+            proc_return_val.value = NEXT_RUN_SIGKILL
         else:
             proc_return_val.value = NEXT_RUN_FAILED
 


### PR DESCRIPTION
Similar to https://github.com/mbta/odin/pull/233:

> Currently, all uncaught exceptions are retryed at OdinJob's default NEXT_RUN_FAILED delay, which is a full 24 hours. This makes sense when the issue e.g. vendor-side API issues, but less sense when the issue is sporadic runtime errors such as OOM hits.

Which caught SIGSEGV to use a shorter retry delay, this catches SIGKILL, which seems to be related to the same memory pressure concerns.

