### PR TITLE
fix: updating streamed_exec to True

### DIFF
--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -885,7 +885,7 @@ class CubicODSDelta(OdinJob):
             error_on_type_mismatch=False,
             merge_schema=False,
             commit_properties=self._commit_state(watermark),
-            streamed_exec=False,
+            streamed_exec=True,
         )
         result_stats = (
             merger.when_matched_delete(predicate="source.odin_resolved_oper = 'D'")


### PR DESCRIPTION
Setting streamed_exec to `True` to hopefully help address memory safety issues on the write side