### PR TITLE
Add EDW.UNSETTLED_CRDB_ACQ_CONFto odin-delta delta_ods

### DIFF
--- a/src/odin/ingestion/qlik/tables.py
+++ b/src/odin/ingestion/qlik/tables.py
@@ -192,6 +192,7 @@ CUBIC_ODS_DELTA_TABLES_GAMMA = [
 # Tables for the Odin instance named "delta" (not to be confused with the Delta
 # table format these lists configure).
 CUBIC_ODS_DELTA_TABLES_DELTA = [
+    "EDW.UNSETTLED_CRDB_ACQ_CONF",
     "EDW.USE_TRANSACTION",
 ]
 


### PR DESCRIPTION
UNSETTLED_CRDB_ACQ_CONF frequently deletes nearly all of its contents, which means that the legacy fact table creation job will revert to earlier dates (since the most recent remaining entry is old, and the job reads that as the current ingestion point.) The delta fact table creation job doesn't have this problem, so this PR moves it to that for more consistent results.