### PR TITLE
Add z-order sort for delta merge efficiency

### DIFF
--- a/scripts/get_table_status.py
+++ b/scripts/get_table_status.py
@@ -117,9 +117,7 @@ def _fmt_count(value: Any) -> str:
     return f"{value:,}" if isinstance(value, int) else str(value)
 
 
-def fetch_group(
-    prefix: str, tmpdir: str, only: Optional[set[str]] = None
-) -> dict[str, dict]:
+def fetch_group(prefix: str, tmpdir: str, only: Optional[set[str]] = None) -> dict[str, dict]:
     """
     Download status objects under `prefix`; return {table: payload}
     """
@@ -324,7 +322,8 @@ def print_overall(
     lag_seconds: float,
     detailed: bool = False,
 ) -> int:
-    """Print the summary for `groups`; return the count of not-OK tables.
+    """
+    Print the summary for `groups`; return the count of not-OK tables.
 
     When `detailed`, every table gets a per-table line (OK tables included, with a
     key-info summary); otherwise only not-OK tables are listed.
@@ -424,9 +423,7 @@ def main() -> int:
     # Single table: fetch just that table's object, not the whole group.
     if args.table:
         with tempfile.TemporaryDirectory() as tmpdir:
-            payloads = fetch_group(
-                GROUPS[args.group]["prefix"], tmpdir, only={args.table}
-            )
+            payloads = fetch_group(GROUPS[args.group]["prefix"], tmpdir, only={args.table})
         payload = payloads.get(args.table, {})
         if args.json:
             print(json.dumps(payload, indent=2))

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -893,10 +893,11 @@ class CubicODSDelta(OdinJob):
         among the table's columns.
         """
         dfm = self._dfm_from_records(cdc_df)
+        key_info = [c for c in dfm["dataInfo"]["columns"] if c["primaryKeyPos"] > 0]
+        assert len(set([c['primaryKeyPos'] for c in key_info])) == len(key_info)
         keys = [
             col["name"].lower()
-            for col in sorted(
-                (c for c in dfm["dataInfo"]["columns"] if c["primaryKeyPos"] > 0),
+            for col in sorted(key_info,
                 key=lambda c: c["primaryKeyPos"],
             )
         ]

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -106,6 +106,7 @@ NEXT_RUN_LONG = 60 * 60 * 12  # 12 hours
 
 REBUILD_BATCH_SIZE = 10_000
 MAX_MERGE_RECORDS = 150_000
+MAX_CHUNK_RECORDS = 25_000
 
 CDC_OPERS = ("I", "U", "D")
 
@@ -791,8 +792,9 @@ class CubicODSDelta(OdinJob):
         for unit in units:
             unit_ranges = self._unit_ranges(ranges, unit)
             overlapping = self._overlapping_files(unit_ranges)
-            recluster_threshold = max(RECLUSTER_MIN_OVERLAPPING_FILES,
-                                      math.ceil(2 * math.sqrt(unit_ranges.height)))
+            recluster_threshold = max(
+                RECLUSTER_MIN_OVERLAPPING_FILES, math.ceil(2 * math.sqrt(unit_ranges.height))
+            )
             if overlapping is not None and overlapping >= recluster_threshold:
                 todo.append((unit, unit_ranges.height, overlapping))
 
@@ -1099,18 +1101,40 @@ class CubicODSDelta(OdinJob):
         )
         return f" AND ({pair_sql})"
 
-    def _partition_chunks(self, source: pl.DataFrame) -> list[pl.DataFrame]:
+    def _partition_chunks(self, source: pl.DataFrame, keys: list[str]) -> list[pl.DataFrame]:
         """
-        Split the merge source into one frame per (odin_year, odin_month) partition.
+        Split the merge source into chunks small enough to merge one at a time.
 
-        Each chunk is merged on its own so delta-rs rewrites only one partition's
-        files per MERGE (see _merge_apply). Non-dated tables lack the partition
-        columns and merge as a single chunk; null-edw rows share the (0, 0) chunk,
-        which _partition_constraint leaves unpruned.
+        Two cuts, in order. First by (odin_year, odin_month), so delta-rs rewrites
+        only one partition's files per MERGE; non-dated tables lack the partition
+        columns and start as one chunk, and null-edw rows share the (0, 0) chunk,
+        which _partition_constraint leaves unpruned. Then any chunk still over
+        MAX_CHUNK_RECORDS is cut again into contiguous runs of that size, sorted
+        by key columns.
+
+        The rationale for the latter sort is to reduce the number of files touched
+        by each chunk merge (where files have been sorted by key via z_order().)
         """
-        if "odin_year" not in source.columns or "odin_month" not in source.columns:
-            return [source]
-        return source.partition_by(["odin_year", "odin_month"])
+        chunks = (
+            source.partition_by(["odin_year", "odin_month"])
+            if "odin_year" in source.columns and "odin_month" in source.columns
+            else [source]
+        )
+        if all(chunk.height <= MAX_CHUNK_RECORDS for chunk in chunks):
+            return chunks
+        else:
+            sliced: list[pl.DataFrame] = []
+            for chunk in chunks:
+                if chunk.height <= MAX_CHUNK_RECORDS:
+                    sliced.append(chunk)
+                    continue
+                ordered = chunk.sort(keys)
+                sliced.extend(
+                    ordered.slice(offset, MAX_CHUNK_RECORDS)
+                    for offset in range(0, ordered.height, MAX_CHUNK_RECORDS)
+                )
+            assert sum(map(len, chunks)) == sum(map(len, sliced))
+            return sliced
 
     def _merge_apply(self, source: pl.DataFrame, keys: list[str], watermark: str) -> dict:
         """
@@ -1173,7 +1197,7 @@ class CubicODSDelta(OdinJob):
         # Merge one partition at a time so delta-rs only rewrites a single
         # partition's files per MERGE, bounding peak memory.
         dt = self.silver
-        chunks = self._partition_chunks(source)
+        chunks = self._partition_chunks(source, keys)
         totals: dict = {}
         for chunk in chunks:
             predicate = self._merge_predicate(keys, chunk)
@@ -1208,7 +1232,7 @@ class CubicODSDelta(OdinJob):
             dt = DeltaTable(self.silver_uri)
         self.silver = dt
 
-        log.complete()
+        log.complete(chunks=len(chunks))
         return totals
 
 

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -48,6 +48,7 @@ Steps per run:
      silver watermark into the silver table.
 """
 
+import math
 import os
 import re
 import sched
@@ -112,26 +113,16 @@ DELTA_WRITER_PROPERTIES = WriterProperties(max_row_group_size=64 * 1024, compres
 
 os.environ.setdefault("DELTARS_MAX_CONCURRENCY_TASKS", "4")
 
-# Cap on the size of one silver data file (delta-rs otherwise defaults to 100MB).
-# A MERGE rewrites every file it touches in full, so file size *is* the unit of
-# write amplification: a partition stored as one large file has to be rewritten
-# whole every time. Capping it splits large partitions into several files, so a
-# merge rewrites only the ones actually holding changes.
-#
-# It cannot manufacture small files: a partition whose data is under the cap still
-# writes as a single file, so this only bounds the large end. Splitting only pays
-# once the files are also *ordered* by key — see _recluster_inserted_partitions.
 TARGET_FILE_SIZE_PROPERTY = "delta.targetFileSize"
 TARGET_FILE_SIZE_BYTES = 32 * 1024 * 1024
 
-# Reclustering (z-order) thresholds. A partition is re-sorted by primary key only
-# when its files' key ranges have drifted far enough to cost real scan volume:
-# every overlapping file is one the merge must read whether or not it holds a
-# match. Below these thresholds a rewrite costs more than the scan it saves.
-RECLUSTER_MIN_FILES = 2  # one file has nothing to order against
+# Reclustering (z-order) trigger. A unit — one partition, or the whole table when
+# unpartitioned — is re-sorted by primary key once enough of its files carry a key
+# range overlapping an earlier file's: each of those is a file the merge must read
+# whether or not it holds a match.
 RECLUSTER_MIN_OVERLAPPING_FILES = 4
-# Bins within one partition are rewritten sequentially: this is background
-# maintenance and peak memory matters more here than wall time.
+# Bins within one unit are rewritten sequentially: this is background maintenance
+# and peak memory matters more here than wall time.
 RECLUSTER_MAX_CONCURRENT_TASKS = 1
 
 # Keys under which each Delta commit records the job's input position in its
@@ -180,6 +171,11 @@ def _default_run_interval() -> int:
 def _long_run_interval() -> int:
     """Return the no-new-data rerun interval for the active instance."""
     return NEXT_RUN_BETA if _ODIN_INSTANCE == "beta" else NEXT_RUN_LONG
+
+
+def _unit_label(unit: tuple[int, int] | None) -> str:
+    """Log label for a reclustering unit: a partition, or the whole table."""
+    return "table" if unit is None else f"{unit[0]:04d}-{unit[1]:02d}"
 
 
 def _connect(path: str, spill_dir: str) -> duckdb.DuckDBPyConnection:
@@ -278,10 +274,7 @@ class CubicODSDelta(OdinJob):
         Put delta.targetFileSize on silver when it is missing or stale.
 
         An explicit alter is required rather than just passing ``configuration`` to
-        write_deltalake: that argument only takes effect when the table is *created*,
-        and leaves an existing table's properties untouched even on a full overwrite.
-        Tables built before this setting existed would otherwise keep delta-rs's 100MB
-        default forever, since these tables rebuild only when the snapshot rolls.
+        write_deltalake: that argument only takes effect when the table is *created*.
 
         Committing only on a mismatch makes this a no-op on every run after the first.
         """
@@ -471,9 +464,6 @@ class CubicODSDelta(OdinJob):
             partition_by=self.part_columns or None,
             commit_properties=self._commit_state(INITIAL_WATERMARK),
             writer_properties=DELTA_WRITER_PROPERTIES,
-            # configuration only lands when this write *creates* the table; an
-            # existing table keeps its own properties (_ensure_target_file_size
-            # covers that case). target_file_size applies to this write either way.
             configuration={TARGET_FILE_SIZE_PROPERTY: str(TARGET_FILE_SIZE_BYTES)},
             target_file_size=TARGET_FILE_SIZE_BYTES,
         )
@@ -649,14 +639,7 @@ class CubicODSDelta(OdinJob):
         self.cdc_watermark = max_seq_processed
         self.more_pending = more_pending
 
-        # After the watermark is durable, so an interrupted or failed recluster
-        # costs layout quality and nothing else. Maintenance must never fail a
-        # merge that already committed.
-        try:
-            recluster_metrics = self._recluster_inserted_partitions(source, keys)
-        except Exception as exception:
-            ProcessLog("delta_recluster", table=self.table).failed(exception)
-            recluster_metrics = {"recluster_failed": True}
+        recluster_metrics = self._recluster_inserted_partitions(source, keys)
 
         log.complete(
             cdc_records_processed=cdc_rows,
@@ -710,7 +693,9 @@ class CubicODSDelta(OdinJob):
 
     def _add_action_key_ranges(self, key: str) -> pl.DataFrame | None:
         """
-        Return (odin_year, odin_month, min_key, max_key) per active silver file.
+        Return (min_key, max_key) per active silver file.
+
+        Partition columns are included when the table has them.
 
         Read from the Delta log's add actions, so this costs no data scan — the
         per-file key statistics are already in the commit log.
@@ -718,12 +703,13 @@ class CubicODSDelta(OdinJob):
         :return: one row per active file, or None if `key` carries no statistics
         """
         assert self.silver is not None
-        want = {
-            "partition.odin_year": "odin_year",
-            "partition.odin_month": "odin_month",
-            f"min.{key}": "min_key",
-            f"max.{key}": "max_key",
-        }
+        want = {f"min.{key}": "min_key", f"max.{key}": "max_key"}
+        if self.part_columns:
+            want = {
+                "partition.odin_year": "odin_year",
+                "partition.odin_month": "odin_month",
+                **want,
+            }
         actions = pl.from_arrow(pa.table(self.silver.get_add_actions(flatten=True)))
         assert isinstance(actions, pl.DataFrame)
         if actions.height == 0 or not set(want).issubset(actions.columns):
@@ -758,99 +744,80 @@ class CubicODSDelta(OdinJob):
             running_max = max_key if running_max is None else max(running_max, max_key)
         return overlapping
 
+    def _unit_ranges(self, ranges: pl.DataFrame, unit: tuple[int, int] | None) -> pl.DataFrame:
+        """Narrow per-file key ranges to one reclustering unit (None = whole table)."""
+        if unit is None:
+            return ranges.select("min_key", "max_key")
+        year, month = unit
+        return ranges.filter(
+            (pl.col("odin_year") == year) & (pl.col("odin_month") == month)
+        ).select("min_key", "max_key")
+
     def _recluster_inserted_partitions(self, source: pl.DataFrame, keys: list[str]) -> dict:
         """
-        Re-sort by primary key any partition this batch's inserts disordered.
-
-        Merges do not write key-ordered output. A matched update rewrites its file
-        with the same key set, so the file's range is unchanged; a delete only
-        shrinks it. **Inserts are the only operation that widens a file's range** —
-        an unmatched insert is written into whatever file the writer is filling
-        rather than the key-appropriate one — so the partitions needing attention
-        are exactly the partitions this batch inserted into. Insert-resolved rows
-        are asserted to carry ``edw_inserted_dtm`` (see _merge_apply), so their
-        partitions are already known in memory and this needs no extra state.
+        Re-sort by primary key whatever this batch's inserts disordered.
 
         Ordering matters because file skipping is file-granular: with
         ``streamed_exec=False`` delta-rs derives ``target.k BETWEEN min(source.k)
         AND max(source.k)`` from the merge predicate and applies it to file
         selection, which prunes only when each file covers a narrow key range.
-
-        This is maintenance, not correctness. ``z_order`` is a pure layout
-        operation — same rows, statistics recomputed from what was actually
-        written — so a pass that reorders differently than expected costs scan
-        volume, never a missed target row. The overlap counts are logged before
-        and after for exactly that reason: they are how a regression here shows up.
-
-        Unpartitioned tables are skipped: reclustering one would be an unbounded
-        whole-table rewrite, and they get no partition pruning to protect anyway.
         """
-        if not self.part_columns or self.silver is None or "odin_year" not in source.columns:
+        if self.silver is None or source.filter(pl.col("odin_resolved_oper") == "I").height == 0:
             return {}
-        inserted = (
-            source.filter(pl.col("odin_resolved_oper") == "I")
-            .select("odin_year", "odin_month")
-            .unique()
-            .sort("odin_year", "odin_month")
-        )
-        if inserted.height == 0:
-            return {}
+        partitioned = bool(self.part_columns) and "odin_year" in source.columns
+        units: list[tuple[int, int] | None]
+        if partitioned:
+            units = list(
+                source.filter(pl.col("odin_resolved_oper") == "I")
+                .select("odin_year", "odin_month")
+                .unique()
+                .sort("odin_year", "odin_month")
+                .iter_rows()
+            )
+        else:
+            units = [None]
 
         key = keys[0]
-        log = ProcessLog(
-            "delta_recluster", table=self.table, key=key, partitions_inserted=inserted.height
-        )
+        log = ProcessLog("delta_recluster", table=self.table, key=key, units_inserted=len(units))
         ranges = self._add_action_key_ranges(key)
         if ranges is None:
             log.complete(reclustered=0, skipped_no_key_stats=True)
             return {"recluster_no_key_stats": True}
 
-        # Measured once, up front: z-ordering one partition does not move another's
-        # files, so the pre-pass statistics stay valid for every partition here and
-        # the log is replayed once instead of per partition.
-        todo: list[tuple[int, int, int, int]] = []
-        for year, month in inserted.iter_rows():
-            part = ranges.filter(
-                (pl.col("odin_year") == year) & (pl.col("odin_month") == month)
-            ).select("min_key", "max_key")
-            if part.height < RECLUSTER_MIN_FILES:
-                continue
-            overlapping = self._overlapping_files(part)
-            if overlapping is not None and overlapping >= RECLUSTER_MIN_OVERLAPPING_FILES:
-                todo.append((year, month, part.height, overlapping))
+        # Measured once, up front: z-ordering one unit does not move another's files,
+        # so the pre-pass statistics stay valid for every unit here and the log is
+        # replayed once instead of per unit.
+        todo: list[tuple[tuple[int, int] | None, int, int]] = []
+        for unit in units:
+            unit_ranges = self._unit_ranges(ranges, unit)
+            overlapping = self._overlapping_files(unit_ranges)
+            recluster_threshold = max(RECLUSTER_MIN_OVERLAPPING_FILES,
+                                      math.ceil(2 * math.sqrt(unit_ranges.height)))
+            if overlapping is not None and overlapping >= recluster_threshold:
+                todo.append((unit, unit_ranges.height, overlapping))
 
-        for year, month, files, overlapping in todo:
-            sigterm_check()
-            log.add_metadata(step=f"z_order:{year:04d}-{month:02d}:files={files}")
+        for unit, _, _ in todo:
             self.silver.optimize.z_order(
                 [key],
-                partition_filters=[
-                    ("odin_year", "=", str(year)),
-                    ("odin_month", "=", str(month)),
-                ],
+                partition_filters=None
+                if unit is None
+                else [("odin_year", "=", str(unit[0])), ("odin_month", "=", str(unit[1]))],
                 target_size=TARGET_FILE_SIZE_BYTES,
                 max_concurrent_tasks=RECLUSTER_MAX_CONCURRENT_TASKS,
                 writer_properties=DELTA_WRITER_PROPERTIES,
             )
             self.silver = DeltaTable(self.silver_uri)
 
-        metrics: dict = {"recluster_partitions": len(todo)}
+        metrics: dict = {"recluster_units": len(todo)}
         if todo:
             metrics["recluster_before"] = ",".join(
-                f"{y:04d}-{m:02d}={o}/{f}" for y, m, f, o in todo
+                f"{_unit_label(unit)}={overlapping}/{files}" for unit, files, overlapping in todo
             )
             after = self._add_action_key_ranges(key)
             if after is not None:
                 metrics["recluster_after"] = ",".join(
-                    f"{y:04d}-{m:02d}="
-                    + str(
-                        self._overlapping_files(
-                            after.filter(
-                                (pl.col("odin_year") == y) & (pl.col("odin_month") == m)
-                            ).select("min_key", "max_key")
-                        )
-                    )
-                    for y, m, _, _ in todo
+                    f"{_unit_label(unit)}={self._overlapping_files(self._unit_ranges(after, unit))}"
+                    for unit, _, _ in todo
                 )
         log.complete(**metrics)
         return metrics
@@ -1126,12 +1093,6 @@ class CubicODSDelta(OdinJob):
         )
         if not pairs:
             return ""
-        # Literals are cast to INT (Int32) to match the partition columns' type
-        # exactly: bare integer literals parse as Int64, and while DataFusion's
-        # planner coerces that, delta-rs also evaluates this predicate in strict
-        # non-coercing paths (kernel data skipping, concurrent-commit conflict
-        # checks) where an Int32/Int64 comparison is a hard error
-        # ("Invalid comparison operation: Int32 <= Int64").
         pair_sql = " OR ".join(
             f'(target."odin_year" = CAST({y} AS INT) AND target."odin_month" = CAST({m} AS INT))'
             for y, m in pairs
@@ -1175,11 +1136,6 @@ class CubicODSDelta(OdinJob):
             f"primary key columns {sorted(missing)} absent from silver table for {self.table}"
         )
 
-        # On partitioned tables, every "I"-resolved row (replaced or inserted
-        # with verbatim partition values) must carry edw_inserted_dtm: without
-        # it the row would land in the odin_year=0 partition, which
-        # partition-pruned merge scans never revisit. "U" rows are exempt —
-        # they keep the target's partition (see update_set below).
         if "odin_year" in source.columns:
             inserts = source.filter(pl.col("odin_resolved_oper") == "I")
             null_edw = inserts.get_column("edw_inserted_dtm").null_count()
@@ -1189,14 +1145,6 @@ class CubicODSDelta(OdinJob):
                 "partition, which partition-pruned merges never revisit"
             )
 
-        # "U" rows (sparse update): watermark columns verbatim from the
-        # resolved CDC row; data columns coalesce so untouched target values
-        # survive. Partition columns follow edw_inserted_dtm: when no CDC
-        # record in the batch carried it for a key, source odin_year/odin_month
-        # degrade to 0 while the coalesce keeps the target's edw_inserted_dtm —
-        # so the target's partition values must be kept too, or the row would
-        # silently move to the 0/0 partition and out of partition-pruned
-        # query results.
         passthrough = {"odin_snapshot", "header__change_seq"}
         partition_cols = {"odin_year", "odin_month"}
         source_cols = set(source.columns)
@@ -1207,32 +1155,28 @@ class CubicODSDelta(OdinJob):
             if col in passthrough:
                 update_set[col] = f'source."{col}"'
             elif col in partition_cols:
+                # Only update partition_cols (odin_year, odin_month) if there is
+                # a non-null edw_inserted_dtm from which they could be derived,
+                # otherwise retain the previous values.
                 update_set[col] = (
                     'CASE WHEN source."edw_inserted_dtm" IS NOT NULL '
                     f'THEN source."{col}" ELSE target."{col}" END'
                 )
             else:
                 update_set[col] = f'COALESCE(source."{col}", target."{col}")'
-        # "I" rows replace a matched row wholesale (delete-then-reinsert within
-        # one batch, or a duplicate/replayed insert — the spec's idempotent
-        # upsert): the fold is anchored at the insert image, so a NULL in the
-        # source means NULL — coalescing against the target would resurrect
-        # pre-reset values. Partition columns are safe verbatim per the assert
-        # above.
+
         replace_set = {
             col: f'source."{col}"' for col in target_cols if col in source_cols and col not in keys
         }
         insert_set = {col: f'source."{col}"' for col in target_cols if col in source_cols}
 
         # Merge one partition at a time so delta-rs only rewrites a single
-        # partition's files per MERGE, bounding peak memory to the largest single
-        # partition rather than every touched partition's rewrite at once.
+        # partition's files per MERGE, bounding peak memory.
         dt = self.silver
         chunks = self._partition_chunks(source)
         totals: dict = {}
         for chunk in chunks:
             predicate = self._merge_predicate(keys, chunk)
-            sigterm_check()
             log.add_metadata(step=f"merging_chunk:{len(chunk)}")
             merger = dt.merge(
                 source=chunk.to_arrow(),

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -112,6 +112,28 @@ DELTA_WRITER_PROPERTIES = WriterProperties(max_row_group_size=64 * 1024, compres
 
 os.environ.setdefault("DELTARS_MAX_CONCURRENCY_TASKS", "4")
 
+# Cap on the size of one silver data file (delta-rs otherwise defaults to 100MB).
+# A MERGE rewrites every file it touches in full, so file size *is* the unit of
+# write amplification: a partition stored as one large file has to be rewritten
+# whole every time. Capping it splits large partitions into several files, so a
+# merge rewrites only the ones actually holding changes.
+#
+# It cannot manufacture small files: a partition whose data is under the cap still
+# writes as a single file, so this only bounds the large end. Splitting only pays
+# once the files are also *ordered* by key — see _recluster_inserted_partitions.
+TARGET_FILE_SIZE_PROPERTY = "delta.targetFileSize"
+TARGET_FILE_SIZE_BYTES = 32 * 1024 * 1024
+
+# Reclustering (z-order) thresholds. A partition is re-sorted by primary key only
+# when its files' key ranges have drifted far enough to cost real scan volume:
+# every overlapping file is one the merge must read whether or not it holds a
+# match. Below these thresholds a rewrite costs more than the scan it saves.
+RECLUSTER_MIN_FILES = 2  # one file has nothing to order against
+RECLUSTER_MIN_OVERLAPPING_FILES = 4
+# Bins within one partition are rewritten sequentially: this is background
+# maintenance and peak memory matters more here than wall time.
+RECLUSTER_MAX_CONCURRENT_TASKS = 1
+
 # Keys under which each Delta commit records the job's input position in its
 # custom metadata (readable via DeltaTable.history()). This is the source of
 # truth for "where the table is at", independent of the surviving row contents.
@@ -225,6 +247,8 @@ class CubicODSDelta(OdinJob):
         try:
             self.silver = open_delta(self.silver_uri)
             self._snapshot_check()
+            # Before anything writes, so a rebuild on this run is already capped.
+            self._ensure_target_file_size()
 
             silver_snapshot, cdc_watermark = self._read_state()
             if self.history_snapshot != silver_snapshot:
@@ -248,6 +272,31 @@ class CubicODSDelta(OdinJob):
             raise e
         finally:
             self._close_db()
+
+    def _ensure_target_file_size(self) -> None:
+        """
+        Put delta.targetFileSize on silver when it is missing or stale.
+
+        An explicit alter is required rather than just passing ``configuration`` to
+        write_deltalake: that argument only takes effect when the table is *created*,
+        and leaves an existing table's properties untouched even on a full overwrite.
+        Tables built before this setting existed would otherwise keep delta-rs's 100MB
+        default forever, since these tables rebuild only when the snapshot rolls.
+
+        Committing only on a mismatch makes this a no-op on every run after the first.
+        """
+        if self.silver is None:
+            return
+        target = str(TARGET_FILE_SIZE_BYTES)
+        if self.silver.metadata().configuration.get(TARGET_FILE_SIZE_PROPERTY) == target:
+            return
+        self.silver.alter.set_table_properties({TARGET_FILE_SIZE_PROPERTY: target})
+        self.silver = DeltaTable(self.silver_uri)
+        ProcessLog(
+            "delta_set_target_file_size",
+            table=self.table,
+            target_file_size=target,
+        ).complete()
 
     def _db(self) -> duckdb.DuckDBPyConnection:
         """Return the run-scoped DuckDB connection, creating it on first use."""
@@ -422,6 +471,11 @@ class CubicODSDelta(OdinJob):
             partition_by=self.part_columns or None,
             commit_properties=self._commit_state(INITIAL_WATERMARK),
             writer_properties=DELTA_WRITER_PROPERTIES,
+            # configuration only lands when this write *creates* the table; an
+            # existing table keeps its own properties (_ensure_target_file_size
+            # covers that case). target_file_size applies to this write either way.
+            configuration={TARGET_FILE_SIZE_PROPERTY: str(TARGET_FILE_SIZE_BYTES)},
+            target_file_size=TARGET_FILE_SIZE_BYTES,
         )
 
         self.silver = DeltaTable(self.silver_uri)
@@ -595,6 +649,15 @@ class CubicODSDelta(OdinJob):
         self.cdc_watermark = max_seq_processed
         self.more_pending = more_pending
 
+        # After the watermark is durable, so an interrupted or failed recluster
+        # costs layout quality and nothing else. Maintenance must never fail a
+        # merge that already committed.
+        try:
+            recluster_metrics = self._recluster_inserted_partitions(source, keys)
+        except Exception as exception:
+            ProcessLog("delta_recluster", table=self.table).failed(exception)
+            recluster_metrics = {"recluster_failed": True}
+
         log.complete(
             cdc_records_processed=cdc_rows,
             merge_source_rows=source.height,
@@ -604,6 +667,7 @@ class CubicODSDelta(OdinJob):
             key_cols=",".join(keys),
             **{f"merge_{k}": v for k, v in metrics.items()},
             **self._partition_metrics(source),
+            **recluster_metrics,
         )
         return NEXT_RUN_IMMEDIATE if more_pending else _default_run_interval()
 
@@ -642,6 +706,153 @@ class CubicODSDelta(OdinJob):
         unknown = source.get_column("edw_inserted_dtm").null_count()
         if unknown:
             metrics["partition_rows_unknown"] = unknown
+        return metrics
+
+    def _add_action_key_ranges(self, key: str) -> pl.DataFrame | None:
+        """
+        Return (odin_year, odin_month, min_key, max_key) per active silver file.
+
+        Read from the Delta log's add actions, so this costs no data scan — the
+        per-file key statistics are already in the commit log.
+
+        :return: one row per active file, or None if `key` carries no statistics
+        """
+        assert self.silver is not None
+        want = {
+            "partition.odin_year": "odin_year",
+            "partition.odin_month": "odin_month",
+            f"min.{key}": "min_key",
+            f"max.{key}": "max_key",
+        }
+        actions = pl.from_arrow(pa.table(self.silver.get_add_actions(flatten=True)))
+        assert isinstance(actions, pl.DataFrame)
+        if actions.height == 0 or not set(want).issubset(actions.columns):
+            # No stats for the key: it falls outside delta.dataSkippingNumIndexedCols
+            # (32 leading columns by default), so no layout makes it prunable and
+            # reclustering cannot pay. Set delta.dataSkippingStatsColumns to fix.
+            return None
+        return actions.select([pl.col(src).alias(dst) for src, dst in want.items()])
+
+    @staticmethod
+    def _overlapping_files(ranges: pl.DataFrame) -> int | None:
+        """
+        Count files whose key range overlaps that of a file ordering before it.
+
+        A partition sorted by key has disjoint per-file ranges and scores 0; each
+        file written out of order (an insert lands in whatever file the writer is
+        filling, widening its range) adds one. The count is what the merge pays:
+        an overlapping file cannot be skipped by the key predicate, so it is read
+        whether or not it holds a match.
+
+        :return: overlapping file count, or None when any file lacks statistics
+            (unmeasurable, so no rewrite is justified)
+        """
+        measurable = ranges.drop_nulls()
+        if measurable.height < ranges.height:
+            return None
+        overlapping = 0
+        running_max = None
+        for min_key, max_key in measurable.sort("min_key").select("min_key", "max_key").iter_rows():
+            if running_max is not None and min_key <= running_max:
+                overlapping += 1
+            running_max = max_key if running_max is None else max(running_max, max_key)
+        return overlapping
+
+    def _recluster_inserted_partitions(self, source: pl.DataFrame, keys: list[str]) -> dict:
+        """
+        Re-sort by primary key any partition this batch's inserts disordered.
+
+        Merges do not write key-ordered output. A matched update rewrites its file
+        with the same key set, so the file's range is unchanged; a delete only
+        shrinks it. **Inserts are the only operation that widens a file's range** —
+        an unmatched insert is written into whatever file the writer is filling
+        rather than the key-appropriate one — so the partitions needing attention
+        are exactly the partitions this batch inserted into. Insert-resolved rows
+        are asserted to carry ``edw_inserted_dtm`` (see _merge_apply), so their
+        partitions are already known in memory and this needs no extra state.
+
+        Ordering matters because file skipping is file-granular: with
+        ``streamed_exec=False`` delta-rs derives ``target.k BETWEEN min(source.k)
+        AND max(source.k)`` from the merge predicate and applies it to file
+        selection, which prunes only when each file covers a narrow key range.
+
+        This is maintenance, not correctness. ``z_order`` is a pure layout
+        operation — same rows, statistics recomputed from what was actually
+        written — so a pass that reorders differently than expected costs scan
+        volume, never a missed target row. The overlap counts are logged before
+        and after for exactly that reason: they are how a regression here shows up.
+
+        Unpartitioned tables are skipped: reclustering one would be an unbounded
+        whole-table rewrite, and they get no partition pruning to protect anyway.
+        """
+        if not self.part_columns or self.silver is None or "odin_year" not in source.columns:
+            return {}
+        inserted = (
+            source.filter(pl.col("odin_resolved_oper") == "I")
+            .select("odin_year", "odin_month")
+            .unique()
+            .sort("odin_year", "odin_month")
+        )
+        if inserted.height == 0:
+            return {}
+
+        key = keys[0]
+        log = ProcessLog(
+            "delta_recluster", table=self.table, key=key, partitions_inserted=inserted.height
+        )
+        ranges = self._add_action_key_ranges(key)
+        if ranges is None:
+            log.complete(reclustered=0, skipped_no_key_stats=True)
+            return {"recluster_no_key_stats": True}
+
+        # Measured once, up front: z-ordering one partition does not move another's
+        # files, so the pre-pass statistics stay valid for every partition here and
+        # the log is replayed once instead of per partition.
+        todo: list[tuple[int, int, int, int]] = []
+        for year, month in inserted.iter_rows():
+            part = ranges.filter(
+                (pl.col("odin_year") == year) & (pl.col("odin_month") == month)
+            ).select("min_key", "max_key")
+            if part.height < RECLUSTER_MIN_FILES:
+                continue
+            overlapping = self._overlapping_files(part)
+            if overlapping is not None and overlapping >= RECLUSTER_MIN_OVERLAPPING_FILES:
+                todo.append((year, month, part.height, overlapping))
+
+        for year, month, files, overlapping in todo:
+            sigterm_check()
+            log.add_metadata(step=f"z_order:{year:04d}-{month:02d}:files={files}")
+            self.silver.optimize.z_order(
+                [key],
+                partition_filters=[
+                    ("odin_year", "=", str(year)),
+                    ("odin_month", "=", str(month)),
+                ],
+                target_size=TARGET_FILE_SIZE_BYTES,
+                max_concurrent_tasks=RECLUSTER_MAX_CONCURRENT_TASKS,
+                writer_properties=DELTA_WRITER_PROPERTIES,
+            )
+            self.silver = DeltaTable(self.silver_uri)
+
+        metrics: dict = {"recluster_partitions": len(todo)}
+        if todo:
+            metrics["recluster_before"] = ",".join(
+                f"{y:04d}-{m:02d}={o}/{f}" for y, m, f, o in todo
+            )
+            after = self._add_action_key_ranges(key)
+            if after is not None:
+                metrics["recluster_after"] = ",".join(
+                    f"{y:04d}-{m:02d}="
+                    + str(
+                        self._overlapping_files(
+                            after.filter(
+                                (pl.col("odin_year") == y) & (pl.col("odin_month") == m)
+                            ).select("min_key", "max_key")
+                        )
+                    )
+                    for y, m, _, _ in todo
+                )
+        log.complete(**metrics)
         return metrics
 
     def _read_cdc(self, after_seq: str, limit: int) -> pl.DataFrame:
@@ -703,10 +914,22 @@ class CubicODSDelta(OdinJob):
         return result
 
     def _discover_keys(self, cdc_df: pl.DataFrame) -> list[str]:
-        """Return the primary-key column names (lowercased) from the table DFM."""
+        """
+        Return the primary-key column names (lowercased) from the table DFM.
+
+        Ordered by ``primaryKeyPos``, not by position in the schema. The MERGE
+        predicate treats the keys symmetrically so the order is immaterial there,
+        but reclustering sorts on ``keys[0]`` — and that has to be the vendor's
+        declared leading key, not whichever key column happens to appear first
+        among the table's columns.
+        """
         dfm = self._dfm_from_records(cdc_df)
         keys = [
-            col["name"].lower() for col in dfm["dataInfo"]["columns"] if col["primaryKeyPos"] > 0
+            col["name"].lower()
+            for col in sorted(
+                (c for c in dfm["dataInfo"]["columns"] if c["primaryKeyPos"] > 0),
+                key=lambda c: c["primaryKeyPos"],
+            )
         ]
         assert keys, f"DFM for {self.table} declares no primary key columns"
         missing = set(keys) - set(cdc_df.columns)

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -894,10 +894,11 @@ class CubicODSDelta(OdinJob):
         """
         dfm = self._dfm_from_records(cdc_df)
         key_info = [c for c in dfm["dataInfo"]["columns"] if c["primaryKeyPos"] > 0]
-        assert len(set([c['primaryKeyPos'] for c in key_info])) == len(key_info)
+        assert len(set([c["primaryKeyPos"] for c in key_info])) == len(key_info)
         keys = [
             col["name"].lower()
-            for col in sorted(key_info,
+            for col in sorted(
+                key_info,
                 key=lambda c: c["primaryKeyPos"],
             )
         ]

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -19,6 +19,7 @@ import pytest
 
 from deltalake import DeltaTable, write_deltalake
 
+from odin.generate.cubic import delta_ods
 from odin.generate.cubic.delta_ods import CubicODSDelta
 
 
@@ -1474,3 +1475,201 @@ def test_merge_cdc_quotes_reserved_word_columns(job):
     out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table()).sort("txn_id")
     assert out.get_column("txn_id").to_list() == [1, 2]
     assert out.get_column("order").to_list() == ["b", "c"]
+
+
+# --- File layout: target file size, key order, reclustering -------------------
+
+# Silver shape used by the reclustering tests: a key column plus the partition
+# columns, which is all the layout logic looks at.
+_RECLUSTER_FIELDS: "list[pa.Field[Any]]" = [
+    pa.field("txn_id", pa.int64()),
+    pa.field("amount", pa.int64()),
+    pa.field("odin_year", pa.int32()),
+    pa.field("odin_month", pa.int32()),
+]
+RECLUSTER_SCHEMA = pa.schema(_RECLUSTER_FIELDS)
+
+
+def write_silver_files(uri: str, batches: list[list[tuple[int, int]]]) -> None:
+    """
+    Write one silver data file per batch of (txn_id, month) pairs.
+
+    Each append commits its own file, which is how a partition ends up holding
+    several files with overlapping key ranges.
+    """
+    for index, batch in enumerate(batches):
+        table = pa.Table.from_pylist(
+            [
+                {"txn_id": txn_id, "amount": txn_id, "odin_year": 2025, "odin_month": month}
+                for txn_id, month in batch
+            ],
+            schema=RECLUSTER_SCHEMA,
+        )
+        write_deltalake(
+            uri,
+            table,
+            mode="overwrite" if index == 0 else "append",
+            partition_by=["odin_year", "odin_month"],
+        )
+
+
+def recluster_source(partitions: list[tuple[int, int]], oper: str = "I") -> pl.DataFrame:
+    """Minimal merge source naming the partitions its resolved rows land in."""
+    return pl.DataFrame(
+        {
+            "odin_resolved_oper": [oper] * len(partitions),
+            "odin_year": [y for y, _ in partitions],
+            "odin_month": [m for _, m in partitions],
+        },
+        schema={"odin_resolved_oper": pl.String, "odin_year": pl.Int32, "odin_month": pl.Int32},
+    )
+
+
+def test_ensure_target_file_size_sets_then_leaves_property(job):
+    """The property is committed once and the call is a no-op afterwards."""
+    pipeline, write_history, _, _ = job
+    write_history(history_rows([{"txn_id": 1, "amount": 10, "header__change_oper": "L"}]))
+    pipeline._rebuild_silver()
+
+    pipeline.silver = DeltaTable(pipeline.silver_uri)
+    pipeline._ensure_target_file_size()
+    config = DeltaTable(pipeline.silver_uri).metadata().configuration
+    assert config["delta.targetFileSize"] == str(delta_ods.TARGET_FILE_SIZE_BYTES)
+
+    version = DeltaTable(pipeline.silver_uri).version()
+    pipeline._ensure_target_file_size()
+    assert DeltaTable(pipeline.silver_uri).version() == version  # no second commit
+
+
+def test_discover_keys_ordered_by_primary_key_position():
+    """keys[0] is the DFM's leading key, not the first key column in the schema."""
+    pipeline = CubicODSDelta("EDW.TEST_TABLE")
+    cdc_df = pl.DataFrame({"txn_id": [1], "status": ["a"], "header__from_csv": [FROM_CSV]})
+    # "status" is primaryKeyPos 1 but appears after "txn_id" among the columns.
+    with patch(
+        "odin.generate.cubic.delta_ods.dfm_from_s3",
+        return_value=mock_dfm_for_keys(["status", "txn_id"]),
+    ):
+        assert pipeline._discover_keys(cdc_df) == ["status", "txn_id"]
+
+
+def test_overlapping_files_counts_out_of_order_files():
+    """Disjoint ranges score 0; each file overlapping an earlier one adds 1."""
+    ordered = pl.DataFrame({"min_key": [1, 11, 21], "max_key": [10, 20, 30]})
+    assert CubicODSDelta._overlapping_files(ordered) == 0
+
+    overlapping = pl.DataFrame({"min_key": [1, 1, 1, 1], "max_key": [100, 100, 100, 100]})
+    assert CubicODSDelta._overlapping_files(overlapping) == 3
+
+    # A file with no statistics makes the partition unmeasurable, not "ordered".
+    unknown = pl.DataFrame({"min_key": [1, None], "max_key": [10, None]})
+    assert CubicODSDelta._overlapping_files(unknown) is None
+
+
+def test_recluster_reorders_disordered_partition(job):
+    """
+    A partition whose files overlap is z-ordered, and comes back key-ordered.
+
+    The row-order assertion is the point: reclustering relies on a single-column
+    z-order being equivalent to a sort by that column (nothing to interleave), and
+    that is a delta-rs behaviour rather than a documented guarantee. If it ever
+    changes, merges silently lose file skipping and get slower — this test is how
+    that surfaces. Overlap alone would not catch it, since z-order also bin-packs
+    small files and a single output file trivially overlaps nothing.
+    """
+    pipeline, _, _, _ = job
+    pipeline.part_columns = ["odin_year", "odin_month"]
+    # Five files, every one spanning the whole key range: four overlap.
+    write_silver_files(
+        pipeline.silver_uri,
+        [
+            [(1, 1), (100, 1)],
+            [(2, 1), (99, 1)],
+            [(3, 1), (98, 1)],
+            [(4, 1), (97, 1)],
+            [(5, 1), (96, 1)],
+        ],
+    )
+    pipeline.silver = DeltaTable(pipeline.silver_uri)
+    before = pipeline._overlapping_files(
+        pipeline._add_action_key_ranges("txn_id").select("min_key", "max_key")
+    )
+    assert before >= delta_ods.RECLUSTER_MIN_OVERLAPPING_FILES
+
+    metrics = pipeline._recluster_inserted_partitions(recluster_source([(2025, 1)]), ["txn_id"])
+
+    assert metrics["recluster_partitions"] == 1
+    after = pipeline._overlapping_files(
+        pipeline._add_action_key_ranges("txn_id").select("min_key", "max_key")
+    )
+    assert after == 0
+    # Layout only: the same rows, now in key order.
+    out = DeltaTable(pipeline.silver_uri).to_pyarrow_table().column("txn_id").to_pylist()
+    assert out == [1, 2, 3, 4, 5, 96, 97, 98, 99, 100]
+
+
+def test_recluster_leaves_ordered_partition_alone(job):
+    """Below the overlap threshold nothing is rewritten."""
+    pipeline, _, _, _ = job
+    pipeline.part_columns = ["odin_year", "odin_month"]
+    write_silver_files(
+        pipeline.silver_uri, [[(1, 1), (10, 1)], [(11, 1), (20, 1)], [(21, 1), (30, 1)]]
+    )
+    pipeline.silver = DeltaTable(pipeline.silver_uri)
+    version = DeltaTable(pipeline.silver_uri).version()
+
+    metrics = pipeline._recluster_inserted_partitions(recluster_source([(2025, 1)]), ["txn_id"])
+
+    assert metrics["recluster_partitions"] == 0
+    assert DeltaTable(pipeline.silver_uri).version() == version  # no rewrite committed
+
+
+def test_recluster_skips_partitions_without_inserts(job):
+    """Updates and deletes preserve a file's key range, so they trigger nothing."""
+    pipeline, _, _, _ = job
+    pipeline.part_columns = ["odin_year", "odin_month"]
+    write_silver_files(
+        pipeline.silver_uri,
+        [
+            [(1, 1), (100, 1)],
+            [(2, 1), (99, 1)],
+            [(3, 1), (98, 1)],
+            [(4, 1), (97, 1)],
+            [(5, 1), (96, 1)],
+        ],
+    )
+    pipeline.silver = DeltaTable(pipeline.silver_uri)
+    version = DeltaTable(pipeline.silver_uri).version()
+
+    metrics = pipeline._recluster_inserted_partitions(
+        recluster_source([(2025, 1)], oper="U"), ["txn_id"]
+    )
+
+    assert metrics == {}
+    assert DeltaTable(pipeline.silver_uri).version() == version
+
+
+def test_recluster_skips_unpartitioned_table(job):
+    """An unpartitioned table would be an unbounded whole-table rewrite."""
+    pipeline, write_history, _, _ = job
+    write_history(history_rows([{"txn_id": 1, "amount": 10, "header__change_oper": "L"}]))
+    pipeline._rebuild_silver()
+    pipeline.part_columns = []
+
+    assert pipeline._recluster_inserted_partitions(recluster_source([(2025, 1)]), ["txn_id"]) == {}
+
+
+def test_recluster_reports_missing_key_statistics(job):
+    """A key with no per-file stats cannot be made prunable, so no rewrite happens."""
+    pipeline, _, _, _ = job
+    pipeline.part_columns = ["odin_year", "odin_month"]
+    write_silver_files(pipeline.silver_uri, [[(1, 1)], [(2, 1)]])
+    pipeline.silver = DeltaTable(pipeline.silver_uri)
+    version = DeltaTable(pipeline.silver_uri).version()
+
+    metrics = pipeline._recluster_inserted_partitions(
+        recluster_source([(2025, 1)]), ["not_a_column"]
+    )
+
+    assert metrics == {"recluster_no_key_stats": True}
+    assert DeltaTable(pipeline.silver_uri).version() == version

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -1490,12 +1490,20 @@ _RECLUSTER_FIELDS: "list[pa.Field[Any]]" = [
 RECLUSTER_SCHEMA = pa.schema(_RECLUSTER_FIELDS)
 
 
-def write_silver_files(uri: str, batches: list[list[tuple[int, int]]]) -> None:
+# Eight files, every one spanning nearly the whole key range, so seven overlap a
+# file ordering before them — past the threshold for a unit of this size.
+WIDE_RANGE_FILES = [[(i, 1), (101 - i, 1)] for i in range(1, 9)]
+WIDE_RANGE_KEYS = sorted(k for batch in WIDE_RANGE_FILES for k, _ in batch)
+
+
+def write_silver_files(
+    uri: str, batches: list[list[tuple[int, int]]], partitioned: bool = True
+) -> None:
     """
     Write one silver data file per batch of (txn_id, month) pairs.
 
-    Each append commits its own file, which is how a partition ends up holding
-    several files with overlapping key ranges.
+    Each append commits its own file, which is how a unit ends up holding several
+    files with overlapping key ranges.
     """
     for index, batch in enumerate(batches):
         table = pa.Table.from_pylist(
@@ -1509,12 +1517,18 @@ def write_silver_files(uri: str, batches: list[list[tuple[int, int]]]) -> None:
             uri,
             table,
             mode="overwrite" if index == 0 else "append",
-            partition_by=["odin_year", "odin_month"],
+            partition_by=["odin_year", "odin_month"] if partitioned else None,
         )
 
 
-def recluster_source(partitions: list[tuple[int, int]], oper: str = "I") -> pl.DataFrame:
-    """Minimal merge source naming the partitions its resolved rows land in."""
+def recluster_source(
+    partitions: list[tuple[int, int]] | None = None, oper: str = "I"
+) -> pl.DataFrame:
+    """Minimal merge source, naming the partitions its resolved rows land in."""
+    if partitions is None:  # unpartitioned table: no partition columns to carry
+        return pl.DataFrame(
+            {"odin_resolved_oper": [oper]}, schema={"odin_resolved_oper": pl.String}
+        )
     return pl.DataFrame(
         {
             "odin_resolved_oper": [oper] * len(partitions),
@@ -1579,33 +1593,23 @@ def test_recluster_reorders_disordered_partition(job):
     """
     pipeline, _, _, _ = job
     pipeline.part_columns = ["odin_year", "odin_month"]
-    # Five files, every one spanning the whole key range: four overlap.
-    write_silver_files(
-        pipeline.silver_uri,
-        [
-            [(1, 1), (100, 1)],
-            [(2, 1), (99, 1)],
-            [(3, 1), (98, 1)],
-            [(4, 1), (97, 1)],
-            [(5, 1), (96, 1)],
-        ],
-    )
+    write_silver_files(pipeline.silver_uri, WIDE_RANGE_FILES)
     pipeline.silver = DeltaTable(pipeline.silver_uri)
     before = pipeline._overlapping_files(
         pipeline._add_action_key_ranges("txn_id").select("min_key", "max_key")
     )
-    assert before >= delta_ods.RECLUSTER_MIN_OVERLAPPING_FILES
+    assert before >= delta_ods._recluster_threshold(len(WIDE_RANGE_FILES))
 
     metrics = pipeline._recluster_inserted_partitions(recluster_source([(2025, 1)]), ["txn_id"])
 
-    assert metrics["recluster_partitions"] == 1
+    assert metrics["recluster_units"] == 1
     after = pipeline._overlapping_files(
         pipeline._add_action_key_ranges("txn_id").select("min_key", "max_key")
     )
     assert after == 0
     # Layout only: the same rows, now in key order.
     out = DeltaTable(pipeline.silver_uri).to_pyarrow_table().column("txn_id").to_pylist()
-    assert out == [1, 2, 3, 4, 5, 96, 97, 98, 99, 100]
+    assert out == WIDE_RANGE_KEYS
 
 
 def test_recluster_leaves_ordered_partition_alone(job):
@@ -1620,7 +1624,7 @@ def test_recluster_leaves_ordered_partition_alone(job):
 
     metrics = pipeline._recluster_inserted_partitions(recluster_source([(2025, 1)]), ["txn_id"])
 
-    assert metrics["recluster_partitions"] == 0
+    assert metrics["recluster_units"] == 0
     assert DeltaTable(pipeline.silver_uri).version() == version  # no rewrite committed
 
 
@@ -1649,14 +1653,36 @@ def test_recluster_skips_partitions_without_inserts(job):
     assert DeltaTable(pipeline.silver_uri).version() == version
 
 
-def test_recluster_skips_unpartitioned_table(job):
-    """An unpartitioned table would be an unbounded whole-table rewrite."""
-    pipeline, write_history, _, _ = job
-    write_history(history_rows([{"txn_id": 1, "amount": 10, "header__change_oper": "L"}]))
-    pipeline._rebuild_silver()
-    pipeline.part_columns = []
+def test_recluster_sorts_unpartitioned_table_as_one_unit(job):
+    """
+    With no partition columns the whole table is the unit, and it still reclusters.
 
-    assert pipeline._recluster_inserted_partitions(recluster_source([(2025, 1)]), ["txn_id"]) == {}
+    An unpartitioned table needs this more than a partitioned one: the merge has no
+    partition constraint, so the key range is the only thing that can skip a file.
+    """
+    pipeline, _, _, _ = job
+    pipeline.part_columns = []
+    write_silver_files(pipeline.silver_uri, WIDE_RANGE_FILES, partitioned=False)
+    pipeline.silver = DeltaTable(pipeline.silver_uri)
+
+    metrics = pipeline._recluster_inserted_partitions(recluster_source(), ["txn_id"])
+
+    assert metrics["recluster_units"] == 1
+    assert metrics["recluster_before"].startswith("table=")
+    assert pipeline._overlapping_files(pipeline._add_action_key_ranges("txn_id")) == 0
+    out = DeltaTable(pipeline.silver_uri).to_pyarrow_table().column("txn_id").to_pylist()
+    assert out == WIDE_RANGE_KEYS
+
+
+def test_recluster_threshold_scales_with_file_count():
+    """Bigger units need proportionally more damage before a rewrite repays itself."""
+    # Small units keep the floor, and can never reach it: overlap tops out at N-1.
+    assert delta_ods._recluster_threshold(1) == 4
+    assert delta_ods._recluster_threshold(4) == 4
+    # Past that the 2*sqrt(N) break-even governs, so large units recluster rarely
+    # rather than never.
+    assert delta_ods._recluster_threshold(100) == 20
+    assert delta_ods._recluster_threshold(2500) == 100
 
 
 def test_recluster_reports_missing_key_statistics(job):

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -1598,7 +1598,8 @@ def test_recluster_reorders_disordered_partition(job):
     before = pipeline._overlapping_files(
         pipeline._add_action_key_ranges("txn_id").select("min_key", "max_key")
     )
-    assert before >= delta_ods._recluster_threshold(len(WIDE_RANGE_FILES))
+    # Eight files, seven overlapping — past the ceil(2*sqrt(8)) = 6 threshold.
+    assert before == len(WIDE_RANGE_FILES) - 1
 
     metrics = pipeline._recluster_inserted_partitions(recluster_source([(2025, 1)]), ["txn_id"])
 
@@ -1674,15 +1675,33 @@ def test_recluster_sorts_unpartitioned_table_as_one_unit(job):
     assert out == WIDE_RANGE_KEYS
 
 
-def test_recluster_threshold_scales_with_file_count():
-    """Bigger units need proportionally more damage before a rewrite repays itself."""
-    # Small units keep the floor, and can never reach it: overlap tops out at N-1.
-    assert delta_ods._recluster_threshold(1) == 4
-    assert delta_ods._recluster_threshold(4) == 4
-    # Past that the 2*sqrt(N) break-even governs, so large units recluster rarely
-    # rather than never.
-    assert delta_ods._recluster_threshold(100) == 20
-    assert delta_ods._recluster_threshold(2500) == 100
+def test_recluster_threshold_scales_with_file_count(job):
+    """
+    A bigger unit needs proportionally more damage before a rewrite repays itself.
+
+    Eight files with four overlapping sits above the flat floor but below the
+    ceil(2*sqrt(8)) = 6 break-even, so nothing is rewritten. A fixed threshold of
+    RECLUSTER_MIN_OVERLAPPING_FILES would rewrite here, which is what the scaling
+    exists to avoid on large units.
+    """
+    pipeline, _, _, _ = job
+    pipeline.part_columns = ["odin_year", "odin_month"]
+    write_silver_files(
+        pipeline.silver_uri,
+        [[(1, 1), (100, 1)]] * 5
+        + [[(101, 1), (110, 1)], [(111, 1), (120, 1)], [(121, 1), (130, 1)]],
+    )
+    pipeline.silver = DeltaTable(pipeline.silver_uri)
+    overlapping = pipeline._overlapping_files(
+        pipeline._add_action_key_ranges("txn_id").select("min_key", "max_key")
+    )
+    assert overlapping == delta_ods.RECLUSTER_MIN_OVERLAPPING_FILES
+    version = DeltaTable(pipeline.silver_uri).version()
+
+    metrics = pipeline._recluster_inserted_partitions(recluster_source([(2025, 1)]), ["txn_id"])
+
+    assert metrics["recluster_units"] == 0
+    assert DeltaTable(pipeline.silver_uri).version() == version
 
 
 def test_recluster_reports_missing_key_statistics(job):
@@ -1699,3 +1718,169 @@ def test_recluster_reports_missing_key_statistics(job):
 
     assert metrics == {"recluster_no_key_stats": True}
     assert DeltaTable(pipeline.silver_uri).version() == version
+
+
+# --- Chunking: partition split, then key-ordered size split -------------------
+
+
+def chunk_source(rows: list[dict]) -> pl.DataFrame:
+    """Merge-source frame carrying only what _partition_chunks looks at."""
+    return pl.DataFrame(
+        rows,
+        schema={
+            "txn_id": pl.Int64,
+            "edw_inserted_dtm": pl.Datetime("us"),
+            "odin_year": pl.Int32,
+            "odin_month": pl.Int32,
+        },
+    )
+
+
+def dated_chunk_rows(txn_ids: list[int], year: int, month: int) -> list[dict]:
+    """Rows for one partition, in an order that is not key order."""
+    from datetime import datetime
+
+    return [
+        {
+            "txn_id": txn_id,
+            "edw_inserted_dtm": datetime(year, month, 1),
+            "odin_year": year,
+            "odin_month": month,
+        }
+        for txn_id in txn_ids
+    ]
+
+
+def test_partition_chunks_leaves_small_chunks_whole(job):
+    """Under the size limit, chunking is still one frame per partition."""
+    pipeline, _, _, _ = job
+    source = chunk_source(dated_chunk_rows([3, 1, 2], 2025, 1) + dated_chunk_rows([4], 2025, 3))
+
+    chunks = pipeline._partition_chunks(source, KEYS)
+
+    assert sorted(chunk.height for chunk in chunks) == [1, 3]
+    # No reordering when nothing needs slicing.
+    big = next(chunk for chunk in chunks if chunk.height == 3)
+    assert big.get_column("txn_id").to_list() == [3, 1, 2]
+
+
+def test_partition_chunks_slices_oversized_chunk_in_key_order(job):
+    """
+    An oversized chunk is cut into contiguous runs of keys, not arbitrary slices.
+
+    Key order is what makes the slices useful: delta-rs derives
+    ``target.k BETWEEN min(source.k) AND max(source.k)`` per merge, so slices with
+    disjoint key ranges scan disjoint files. Slicing the same rows in arbitrary
+    order would give every slice the full key range and prune nothing.
+    """
+    pipeline, _, _, _ = job
+    limit = delta_ods.MAX_CHUNK_RECORDS
+    # Shuffled so a correct implementation has to sort rather than luck into order.
+    txn_ids = [((i * 7919) % (limit * 2 + 1)) for i in range(limit * 2 + 1)]
+    source = chunk_source(dated_chunk_rows(txn_ids, 2025, 1))
+
+    chunks = pipeline._partition_chunks(source, KEYS)
+
+    assert [chunk.height for chunk in chunks] == [limit, limit, 1]
+    # Every slice is a contiguous run, so the ranges are disjoint and ascending.
+    ranges = [
+        (chunk.get_column("txn_id").min(), chunk.get_column("txn_id").max()) for chunk in chunks
+    ]
+    for (_, previous_max), (next_min, _) in zip(ranges, ranges[1:]):
+        assert previous_max < next_min
+    # No row is lost or duplicated by the slicing.
+    assert sorted(k for chunk in chunks for k in chunk.get_column("txn_id")) == sorted(txn_ids)
+
+
+def test_partition_chunks_slices_undated_rows_too(job):
+    """The unknown-partition rows are chunked by the same rule as everything else."""
+    pipeline, _, _, _ = job
+    limit = delta_ods.MAX_CHUNK_RECORDS
+    source = chunk_source(
+        [
+            {"txn_id": txn_id, "edw_inserted_dtm": None, "odin_year": 0, "odin_month": 0}
+            for txn_id in reversed(range(limit + 5))
+        ]
+    )
+
+    chunks = pipeline._partition_chunks(source, KEYS)
+
+    assert [chunk.height for chunk in chunks] == [limit, 5]
+    # Still unconstrained (null edw), so each slice merges against every partition —
+    # but against a narrow key range, which is what lets file skipping help.
+    assert pipeline._partition_constraint(chunks[0]) == ""
+    assert chunks[0].get_column("txn_id").to_list() == sorted(chunks[0].get_column("txn_id"))
+
+
+def test_partition_chunks_unpartitioned_table_still_sliced(job):
+    """A table with no partition columns starts as one chunk and is cut by size."""
+    pipeline, _, _, _ = job
+    limit = delta_ods.MAX_CHUNK_RECORDS
+    source = pl.DataFrame({"txn_id": list(reversed(range(limit + 1)))}, schema={"txn_id": pl.Int64})
+
+    chunks = pipeline._partition_chunks(source, KEYS)
+
+    assert [chunk.height for chunk in chunks] == [limit, 1]
+    assert chunks[0].get_column("txn_id").to_list() == sorted(chunks[0].get_column("txn_id"))
+
+
+def test_merge_cdc_across_slices_matches_unsliced_result(job):
+    """
+    A batch cut into several key-ordered slices produces the same table as one merge.
+
+    Slicing changes only how many MERGEs run: each slice keeps a predicate correct on
+    its own, and _build_merge_source has already reduced the batch to one row per key,
+    so no key spans two slices. Inserts, sparse updates and deletes are all present
+    here, across two partitions, so every merge branch crosses a slice boundary.
+    """
+    from datetime import datetime
+
+    pipeline, write_history, _, _ = job
+    jan, mar = datetime(2025, 1, 15), datetime(2025, 3, 20)
+    loads = [
+        {"txn_id": t, "amount": t, "header__change_oper": "L", "edw_inserted_dtm": dt}
+        for t, dt in [(1, jan), (2, jan), (3, mar), (4, mar)]
+    ]
+    cdc = [
+        # update (sparse: no amount), delete, and two inserts spread over both months
+        {
+            "txn_id": 1,
+            "status": "u",
+            "header__change_oper": "U",
+            "header__change_seq": "0001",
+            "edw_inserted_dtm": jan,
+        },
+        {
+            "txn_id": 3,
+            "header__change_oper": "D",
+            "header__change_seq": "0002",
+            "edw_inserted_dtm": mar,
+        },
+        {
+            "txn_id": 5,
+            "amount": 50,
+            "header__change_oper": "I",
+            "header__change_seq": "0003",
+            "edw_inserted_dtm": jan,
+        },
+        {
+            "txn_id": 6,
+            "amount": 60,
+            "header__change_oper": "I",
+            "header__change_seq": "0004",
+            "edw_inserted_dtm": mar,
+        },
+    ]
+    write_history(dated_history_rows(loads + cdc))
+    pipeline._rebuild_silver()
+
+    # One row per slice, so every key is merged in a MERGE of its own.
+    with patch.object(delta_ods, "MAX_CHUNK_RECORDS", 1):
+        pipeline._merge_cdc("0")
+
+    out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table()).sort("txn_id")
+    assert out.get_column("txn_id").to_list() == [1, 2, 4, 5, 6]  # 3 deleted
+    assert out.get_column("amount").to_list() == [1, 2, 4, 50, 60]  # sparse U kept amount
+    assert out.get_column("status").to_list() == ["u", None, None, None, None]
+    assert out.get_column("odin_year").to_list() == [2025] * 5
+    assert out.get_column("odin_month").to_list() == [1, 1, 3, 1, 3]


### PR DESCRIPTION
It turns out that some tables, including SALE_TRANSACTION, don't usually supply edw_inserted_dtm on updates; since this is the source for the odin_year and odin_month columns we currently use for partitioning, the partitioning system doesn't work for these updates and the entire structure has to be scanned to locate the row to be updated. This is probably the source of a lot of the performance issues we've been seeing over the past week.

Several changes to mitigate this:

1. It now sorts the base-level files by the primary key, which is guaranteed to be present in all updates and which in most cases corresponds to the date. This is done using delta-rs' z_order() function, which sorts based on a set of interleaved key; on one key, as it's used here, this is equivalent to a standard sort. For the sake of performance, this is targeted only to partition directories which have been updated on any given run. (Worth noting that the preferable solution (what this is hackily using z_order to replicate) is deltalake's liquid clustering, which delta-rs does not currently support.)
2. We add a step to sort the changes by key value and bound the maximum size of a chunk; this means that both updates that don't include edw_inserted_dtm, and also large batches that all hit one partition, don't hit OOM-causing numbers of target files (instead partitions get incrementally updated by key value.)
3. Set the target_file_size parameter, which tells delta-rs to split files smaller; this allows tighter targeting of updates in key-order, so less data that has to be rewritten per update overall.

