### PR TITLE
Add gamma instance history job, and others

### DIFF
--- a/scripts/get_table_status.py
+++ b/scripts/get_table_status.py
@@ -54,7 +54,6 @@ from odin.utils.locations import DATA_SPRINGBOARD
 from odin.utils.locations import MASABI_STATUS
 from odin.utils.logger import LOGGER_NAME
 
-
 GROUPS: dict[str, dict[str, Any]] = {
     "ODS": {
         "prefix": CUBIC_ODS_FACT_STATUS,
@@ -205,7 +204,7 @@ def _behind_note(payload: dict) -> str:
     if payload.get("caught_up") is False:
         parts.append("hit row limit")
     if payload.get("cdc_budget_nearly_full") is True or payload.get("merge_budget_full") is True:
-        parts.append("running at capacity")
+        parts.append("budget full")
     catchup = payload.get("catchup_processing_seconds")
     if isinstance(catchup, (int, float)) and catchup > 0:
         wall = payload.get("catchup_wall_seconds")
@@ -225,12 +224,7 @@ def _stale_note(table: str, payload: dict, now: datetime) -> str:
         return "status object has no valid last_run"
     ago = _fmt_duration((now - last_run).total_seconds())
     cadence = _fmt_duration(payload.get("next_run_seconds"))
-    seq_lag = payload.get("seq_lag_seconds")
-    if isinstance(seq_lag, (int, float)):
-        backlog = f"backlog {_fmt_duration(seq_lag)}"
-    else:
-        backlog = "up-to-date"
-    return f"last run {ago} ago (cadence {cadence}), {backlog}"
+    return f"last run {ago} ago (cadence {cadence})"
 
 
 def _ok_note(payload: dict, now: datetime) -> str:
@@ -334,13 +328,15 @@ def print_overall(
     When `detailed`, every table gets a per-table line (OK tables included, with a
     key-info summary); otherwise only not-OK tables are listed.
     """
-    print(f"Odin table status  --  {now.strftime('%Y-%m-%dT%H:%MZ')}\n")
+    print(f"Odin table status  --  {now.strftime('%Y-%m-%dT%H:%MZ')}")
+
+    print("\nKey:")
     print(
-        f"BEHIND = Latest timestamp older than {lag_seconds / 3600:g} hours, or more data "
-        "available from source.\n"
-        f"STALE = No successful update in the past {stale_seconds / 3600:g} hours\n"
-        "OK = Up-to-date with source\n"
+        f"\tBEHIND = Timestamp lag greater than {lag_seconds / 3600:g} hours, or "
+        "uningested data remains from source"
     )
+    print(f"\tSTALE = No successful update within {stale_seconds / 3600:g} hours.")
+    print("\tOK = Everything up-to-date")
 
     total_behind = total_stale = total_tables = 0
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/get_table_status.py
+++ b/scripts/get_table_status.py
@@ -54,6 +54,7 @@ from odin.utils.locations import DATA_SPRINGBOARD
 from odin.utils.locations import MASABI_STATUS
 from odin.utils.logger import LOGGER_NAME
 
+
 GROUPS: dict[str, dict[str, Any]] = {
     "ODS": {
         "prefix": CUBIC_ODS_FACT_STATUS,
@@ -117,9 +118,7 @@ def _fmt_count(value: Any) -> str:
     return f"{value:,}" if isinstance(value, int) else str(value)
 
 
-def fetch_group(
-    prefix: str, tmpdir: str, only: Optional[set[str]] = None
-) -> dict[str, dict]:
+def fetch_group(prefix: str, tmpdir: str, only: Optional[set[str]] = None) -> dict[str, dict]:
     """
     Download status objects under `prefix`; return {table: payload}
     """
@@ -225,7 +224,7 @@ def _stale_note(table: str, payload: dict, now: datetime) -> str:
     if last_run is None:
         return "status object has no valid last_run"
     ago = _fmt_duration((now - last_run).total_seconds())
-    cadence = _fmt_duration(payload.get("next_run_seconds")) 
+    cadence = _fmt_duration(payload.get("next_run_seconds"))
     seq_lag = payload.get("seq_lag_seconds")
     if isinstance(seq_lag, (int, float)):
         backlog = f"backlog {_fmt_duration(seq_lag)}"
@@ -335,10 +334,12 @@ def print_overall(
     When `detailed`, every table gets a per-table line (OK tables included, with a
     key-info summary); otherwise only not-OK tables are listed.
     """
-    print(f"Odin table status  --  {now.strftime('%Y-%m-%dT%H:%MZ')}")
+    print(f"Odin table status  --  {now.strftime('%Y-%m-%dT%H:%MZ')}\n")
     print(
-        f"(behind = seq_lag > {lag_seconds / 3600:g}h or a job keep-up flag; "
-        f"stale = no run within {stale_seconds / 3600:g}h)\n"
+        f"BEHIND = Latest timestamp older than {lag_seconds / 3600:g} hours, or more data "
+        "available from source.\n"
+        f"STALE = No successful update in the past {stale_seconds / 3600:g} hours\n"
+        "OK = Up-to-date with source\n"
     )
 
     total_behind = total_stale = total_tables = 0
@@ -430,9 +431,7 @@ def main() -> int:
     # Single table: fetch just that table's object, not the whole group.
     if args.table:
         with tempfile.TemporaryDirectory() as tmpdir:
-            payloads = fetch_group(
-                GROUPS[args.group]["prefix"], tmpdir, only={args.table}
-            )
+            payloads = fetch_group(GROUPS[args.group]["prefix"], tmpdir, only={args.table})
         payload = payloads.get(args.table, {})
         if args.json:
             print(json.dumps(payload, indent=2))

--- a/scripts/get_table_status.py
+++ b/scripts/get_table_status.py
@@ -206,7 +206,7 @@ def _behind_note(payload: dict) -> str:
     if payload.get("caught_up") is False:
         parts.append("hit row limit")
     if payload.get("cdc_budget_nearly_full") is True or payload.get("merge_budget_full") is True:
-        parts.append("budget full")
+        parts.append("running at capacity")
     catchup = payload.get("catchup_processing_seconds")
     if isinstance(catchup, (int, float)) and catchup > 0:
         wall = payload.get("catchup_wall_seconds")
@@ -225,8 +225,13 @@ def _stale_note(table: str, payload: dict, now: datetime) -> str:
     if last_run is None:
         return "status object has no valid last_run"
     ago = _fmt_duration((now - last_run).total_seconds())
-    cadence = _fmt_duration(payload.get("next_run_seconds"))
-    return f"last run {ago} ago (cadence {cadence})"
+    cadence = _fmt_duration(payload.get("next_run_seconds")) 
+    seq_lag = payload.get("seq_lag_seconds")
+    if isinstance(seq_lag, (int, float)):
+        backlog = f"backlog {_fmt_duration(seq_lag)}"
+    else:
+        backlog = "up-to-date"
+    return f"last run {ago} ago (cadence {cadence}), {backlog}"
 
 
 def _ok_note(payload: dict, now: datetime) -> str:
@@ -324,7 +329,8 @@ def print_overall(
     lag_seconds: float,
     detailed: bool = False,
 ) -> int:
-    """Print the summary for `groups`; return the count of not-OK tables.
+    """
+    Print the summary for `groups`; return the count of not-OK tables.
 
     When `detailed`, every table gets a per-table line (OK tables included, with a
     key-info summary); otherwise only not-OK tables are listed.

--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -169,7 +169,7 @@ class CubicODSFact(OdinJob):
 
         try:
             self.fact_snapshot = str(fast_last_mod_ds_max(self.s3_export, "odin_snapshot"))
-            if re.match('[0-9]{8}T[0-9]{6}Z', self.fact_snapshot) is None:
+            if re.match("[0-9]{8}T[0-9]{6}Z", self.fact_snapshot) is None:
                 # If fact_snapshot doesn't match expected format, fail to prevent data loss case
                 raise ValueError("Data exists but found invalid fact_snapshot.")
         except IndexError:

--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -1,10 +1,10 @@
 import os
 import sched
-import re
 import time
 from typing import Any
 from typing import List
 from typing import Tuple
+from datetime import datetime
 
 import polars as pl
 import pyarrow as pa
@@ -169,9 +169,8 @@ class CubicODSFact(OdinJob):
 
         try:
             self.fact_snapshot = str(fast_last_mod_ds_max(self.s3_export, "odin_snapshot"))
-            if re.match("[0-9]{8}T[0-9]{6}Z", self.fact_snapshot) is None:
-                # If fact_snapshot doesn't match expected format, fail to prevent data loss case
-                raise ValueError("Data exists but found invalid fact_snapshot.")
+            # Require fact_snapshot to adhere to date format, else fail to prevent data loss case
+            _ = datetime.strptime(self.fact_snapshot, "%Y%m%dT%H%M%SZ")
         except IndexError:
             self.fact_snapshot = ""
 

--- a/src/odin/generate/cubic/ods_fact.py
+++ b/src/odin/generate/cubic/ods_fact.py
@@ -1,5 +1,6 @@
 import os
 import sched
+import re
 import time
 from typing import Any
 from typing import List
@@ -168,8 +169,8 @@ class CubicODSFact(OdinJob):
 
         try:
             self.fact_snapshot = str(fast_last_mod_ds_max(self.s3_export, "odin_snapshot"))
-            if self.fact_snapshot is None:
-                # Fail to prevent data loss case
+            if re.match('[0-9]{8}T[0-9]{6}Z', self.fact_snapshot) is None:
+                # If fact_snapshot doesn't match expected format, fail to prevent data loss case
                 raise ValueError("Data exists but found invalid fact_snapshot.")
         except IndexError:
             self.fact_snapshot = ""

--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -71,8 +71,10 @@ def start():
 
     # Schedule ODIN Jobs
     schedule_sigterm_check(schedule)
-    if odin_instance in ["alpha", "beta"]:
+    if odin_instance in ["alpha", "beta", "gamma"]:
         schedule_cubic_archive_qlik(schedule)
+
+    if odin_instance in ["alpha", "beta"]:
         schedule_cubic_ods_fact_gen(schedule)
         schedule_delta_ods(schedule)
         schedule_masabi_archive(schedule)


### PR DESCRIPTION
Consolidating a few small changes into a single PR:

- Adds the ODS fact table job to odin-gamma in run.py, so that (along with the changes to table assignment from yesterday) history tables for SALE_TRANSACTION and UNSETTLED_CRDB_ACQ_CONF will update
- Finishes implementing the prevention fix for the Cubic regression issue; snapshot values are now checked against a regex to ensure they're something valid, and if this fails the job throws an exception.
- Cleanup table status script change