### PR TITLE
Reenable DEVICE_LAST_STATE legacy fact job on odin-gamma

### DIFF
--- a/src/odin/ingestion/qlik/tables.py
+++ b/src/odin/ingestion/qlik/tables.py
@@ -48,7 +48,7 @@ TABLE_MANIFEST = {
     "EDW.DEVICE_DIMENSION": ["alpha", "alpha", None],
     "EDW.DEVICE_END_OF_DAY_MSG_COUNT": ["alpha", "alpha", None],
     "EDW.DEVICE_EVENT": ["alpha", "alpha", None],
-    "EDW.DEVICE_LAST_STATE": ["delta", None, "delta"],
+    "EDW.DEVICE_LAST_STATE": ["gamma", "gamma", "gamma"],
     "EDW.EMPLOYEE_DIMENSION": ["alpha", "alpha", None],
     "EDW.EVENT_TYPE_DIMENSION": ["alpha", "alpha", None],
     "EDW.FACILITY_DIMENSION": ["alpha", "alpha", None],

--- a/src/odin/ingestion/qlik/tables.py
+++ b/src/odin/ingestion/qlik/tables.py
@@ -1,3 +1,4 @@
+from typing import Dict, List
 from odin.utils.instance import get_odin_instance
 from odin.utils.logger import ProcessLog
 
@@ -10,7 +11,7 @@ HISTORY_JOB_IND = 0
 LEGACY_FACT_JOB_IND = 1
 DELTA_FACT_JOB_IND = 2
 
-TABLE_MANIFEST = {
+TABLE_MANIFEST: Dict[str, List[str | None]] = {
     "CCH_STAGE.CATEGORIZATION_RULE": ["alpha", "alpha", None],
     "CCH_STAGE.CATEGORY": ["alpha", "alpha", None],
     "CCH_STAGE.REPROCESS_ACTION": ["alpha", "alpha", None],


### PR DESCRIPTION
On Friday I moved DEVICE_LAST_STATE to delta processing on odin-delta; however, it turns out that this table is absolutely gigantic and is projected to take months of processing time to catch up even on delta tables. This PR reenables the legacy job, and moves all processing to gamma, which is currently less utilized (since USE_TRANSACTION is caught up.)