### PR TITLE
Abandon merging by partition in favor of merging by key

### DIFF
--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -21,11 +21,17 @@ a contents-derived watermark would regress and re-read that batch forever.
 
 The source data is treated as untrusted: every run asserts the invariants it
 depends on (required columns present, primary keys declared and present, CDC
-records carry a change sequence, a load snapshot is non-empty, and — on
-year/month-partitioned tables — load and insert images carry a non-null
-``edw_inserted_dtm``, since a row without one would land in an odin_year=0
-partition that the pruned merge scan never revisits). Violations raise rather
-than silently producing a corrupt silver table.
+records carry a change sequence, and a load snapshot is non-empty). Violations
+raise rather than silently producing a corrupt silver table.
+
+Merges match on primary key alone and are cut into key-ordered chunks, never by
+partition, so a MERGE can always find its target row wherever it lives. File
+selection is left to delta-rs, which derives a key-range filter from that
+predicate; the silver table is kept sorted by key so the filter prunes well.
+Partitioning by odin_year/odin_month remains for the reader layout and to bound
+reclustering, but it no longer participates in the merge — which is why a key
+whose ``edw_inserted_dtm`` changes, or a row that never had one, is now ordinary
+data rather than a hazard.
 
 Two Qlik Replicate behaviors are relied on without a runtime check:
   - ``header__change_seq`` is unique per change record, so paging with
@@ -473,14 +479,18 @@ class CubicODSDelta(OdinJob):
         log.complete(rows_loaded=delta_row_count(self.silver))
 
     def _check_load_records(self) -> None:
-        """Assert the snapshot's "L" records can produce a valid silver table."""
-        checks = ["count(*)"]
-        if self.part_columns:
-            checks.append('count(*) FILTER (WHERE "edw_inserted_dtm" IS NULL)')
+        """
+        Assert the snapshot's "L" records can produce a valid silver table.
+
+        A null ``edw_inserted_dtm`` used to be rejected here: such a row landed in
+        the odin_year=0 partition, which a partition-pruned merge never reached.
+        Merges match on key alone now, so that partition is reachable like any
+        other and a table carrying null timestamps simply works.
+        """
         row = (
             self._db()
             .execute(
-                f"SELECT {', '.join(checks)} FROM {self._read_history} "
+                f"SELECT count(*) FROM {self._read_history} "
                 "WHERE snapshot = ? AND header__change_oper = 'L'",
                 [self.history_snapshot],
             )
@@ -489,12 +499,6 @@ class CubicODSDelta(OdinJob):
         assert row is not None and row[0] > 0, (
             f"snapshot {self.history_snapshot} for {self.table} has no L (load) records"
         )
-        if self.part_columns:
-            assert row[1] == 0, (
-                f"snapshot {self.history_snapshot} for {self.table} has {row[1]} L (load) "
-                "records with a null edw_inserted_dtm; rows would land in the odin_year=0 "
-                "partition, which partition-pruned merges never revisit"
-            )
 
     # ------------------------------------------------------------------
     # CDC MERGE (silver update from I/U/D records)
@@ -622,7 +626,6 @@ class CubicODSDelta(OdinJob):
         max_seq_processed = str(max_seq)
 
         keys = self._discover_keys(cdc_df)
-        self._check_partition_stability(cdc_df, keys)
         source = self._build_merge_source(cdc_df, keys)
         # The raw batch holds every CDC record; `source` holds one resolved row per
         # key. Drop the larger of the two before the merge rather than after it.
@@ -663,12 +666,13 @@ class CubicODSDelta(OdinJob):
         """
         Log fields describing the partitions a merge touches (dated tables only).
 
-        Reported from the merge source (the same values _partition_constraint
-        prunes by): how many distinct odin_year/odin_month partitions the batch
-        reaches and the row count landing in each, oldest first — the signal
-        for pathological update patterns (e.g. frequent history-wide sweeps).
-        Rows without edw_inserted_dtm have an unknown target partition; they
-        are counted separately and disable pruning for the whole merge.
+        How many distinct odin_year/odin_month partitions the batch writes to and
+        the row count landing in each, oldest first — the signal for pathological
+        update patterns (e.g. frequent history-wide sweeps). Merges no longer prune
+        by partition, so this describes write spread rather than scan scope: a batch
+        fanned across many partitions opens a parquet writer per partition, which is
+        the memory cost worth watching. Rows without edw_inserted_dtm keep whatever
+        partition their target row already had, and are counted separately.
         """
         if "odin_year" not in source.columns:
             return {}
@@ -685,7 +689,6 @@ class CubicODSDelta(OdinJob):
         metrics = {
             "partitions_touched": parts.height,
             "partition_rows": ",".join(labels),
-            "partition_scan_pruned": bool(self._partition_constraint(source)),
         }
         unknown = source.get_column("edw_inserted_dtm").null_count()
         if unknown:
@@ -909,39 +912,6 @@ class CubicODSDelta(OdinJob):
         )
         return keys
 
-    def _check_partition_stability(self, cdc_df: pl.DataFrame, keys: list[str]) -> None:
-        """
-        Assert no key's CDC records disagree on edw_inserted_dtm.
-
-        Merging one partition at a time means each MERGE scans only the partition
-        its own source rows land in, so a key whose target row lives in a *different*
-        partition is never seen: the row is inserted alongside the old one instead
-        of replacing it, and the key silently duplicates. The whole scheme rests on
-        edw_inserted_dtm being fixed for the life of a key, which makes a row's
-        partition fixed too.
-
-        This is the affordable half of that invariant — it compares a key's records
-        against each other, in memory, and so catches a feed that starts mutating
-        the column (including a delete/re-insert that reuses a primary key with a
-        new timestamp, which a merge chunk cannot resolve). It cannot catch a
-        mutation relative to a row written by an *earlier* batch; confirming that
-        would mean reading every key's current partition out of silver on every
-        run, which costs more than the merge it protects.
-        """
-        if "edw_inserted_dtm" not in cdc_df.columns:
-            return
-        disagreeing = (
-            cdc_df.filter(pl.col("edw_inserted_dtm").is_not_null())
-            .group_by(keys)
-            .agg(pl.col("edw_inserted_dtm").n_unique().alias("distinct_edw"))
-            .filter(pl.col("distinct_edw") > 1)
-        )
-        assert disagreeing.height == 0, (
-            f"{disagreeing.height} key(s) in the {self.table} CDC batch carry more than one "
-            "edw_inserted_dtm; a key's partition must not change or the partition-scoped "
-            f"merge would duplicate it. Offending keys: {disagreeing.head(5).rows()}"
-        )
-
     def _dfm_from_records(self, cdc_df: pl.DataFrame) -> QlikDFM:
         """Locate a DFM for the CDC source CSVs, trying processed then source paths."""
         for candidate in self._dfm_candidates(cdc_df):
@@ -1019,9 +989,8 @@ class CubicODSDelta(OdinJob):
         # Data values: latest non-null per column across the key's records at or
         # after its reset (all records when there is none). By construction this
         # folds I + trailing Us for "I" keys and only Us for "U" keys; for "D"
-        # keys it starts at the delete image itself, whose values are unused by
-        # the delete except edw_inserted_dtm, which _partition_constraint needs
-        # to keep the merge scan pruned (it names the deleted row's partition).
+        # keys it starts at the delete image itself, whose values the delete does
+        # not use.
         folded = (
             cdc_df.join(resets.select(*keys, "_reset_seq"), on=keys, how="left", nulls_equal=True)
             .filter(
@@ -1075,68 +1044,41 @@ class CubicODSDelta(OdinJob):
             else f'(target."{k}" = source."{k}" OR (target."{k}" IS NULL AND source."{k}" IS NULL))'
             for k in keys
         )
-        return key_pred + self._partition_constraint(source)
+        return key_pred
 
-    def _partition_constraint(self, source: pl.DataFrame) -> str:
+    def _merge_chunks(self, source: pl.DataFrame, keys: list[str]) -> list[pl.DataFrame]:
         """
-        Return a partition-pruning clause for the merge, or '' when unsafe.
+        Split the merge source into key-ordered chunks of at most MAX_CHUNK_RECORDS.
 
-        Emits ` AND ((odin_year = Y1 AND odin_month = M1) OR ...)` naming the exact
-        (year, month) partitions the source touches, restricting the scan to just
-        those.
+        The whole source is sorted by key and cut into contiguous runs. Chunking is
+        deliberately *not* done by partition: each chunk's job is to be a narrow key
+        range, so that the ``target.k BETWEEN min(source.k) AND max(source.k)``
+        delta-rs derives under ``streamed_exec=False`` selects only the files
+        covering that range. Files are key-ordered within a partition (z_order, see
+        _recluster_inserted_partitions), and the keys on these tables broadly track
+        the partitioning column, so a key run maps onto a small set of files.
+
+        Chunking by partition instead produced a long tail of tiny merges — a batch
+        touching forty months paid forty commits, forty log replays and forty plans
+        to change a handful of rows each, and that fixed cost dominated the run.
+        Key ranges absorb those scattered rows into whichever run they fall in.
+
+        No chunk carries a partition constraint, so every merge matches purely on
+        key and cannot miss a target row wherever it lives. That is what retires the
+        partition-immutability hazard: pruning is now delta-rs's business, and a
+        poorly-clustered table costs scan time rather than correctness. Partitioning
+        itself stays — it bounds reclustering and gives readers a dated layout — it
+        just no longer decides how the merge is cut.
         """
-        if "odin_year" not in source.columns or "odin_month" not in source.columns:
-            return ""
-        if source.get_column("edw_inserted_dtm").null_count() > 0:
-            return ""
-        pairs = (
-            source.select("odin_year", "odin_month")
-            .unique()
-            .sort(["odin_year", "odin_month"])
-            .rows()
-        )
-        if not pairs:
-            return ""
-        pair_sql = " OR ".join(
-            f'(target."odin_year" = CAST({y} AS INT) AND target."odin_month" = CAST({m} AS INT))'
-            for y, m in pairs
-        )
-        return f" AND ({pair_sql})"
-
-    def _partition_chunks(self, source: pl.DataFrame, keys: list[str]) -> list[pl.DataFrame]:
-        """
-        Split the merge source into chunks small enough to merge one at a time.
-
-        Two cuts, in order. First by (odin_year, odin_month), so delta-rs rewrites
-        only one partition's files per MERGE; non-dated tables lack the partition
-        columns and start as one chunk, and null-edw rows share the (0, 0) chunk,
-        which _partition_constraint leaves unpruned. Then any chunk still over
-        MAX_CHUNK_RECORDS is cut again into contiguous runs of that size, sorted
-        by key columns.
-
-        The rationale for the latter sort is to reduce the number of files touched
-        by each chunk merge (where files have been sorted by key via z_order().)
-        """
-        chunks = (
-            source.partition_by(["odin_year", "odin_month"])
-            if "odin_year" in source.columns and "odin_month" in source.columns
-            else [source]
-        )
-        if all(chunk.height <= MAX_CHUNK_RECORDS for chunk in chunks):
-            return chunks
-        else:
-            sliced: list[pl.DataFrame] = []
-            for chunk in chunks:
-                if chunk.height <= MAX_CHUNK_RECORDS:
-                    sliced.append(chunk)
-                    continue
-                ordered = chunk.sort(keys)
-                sliced.extend(
-                    ordered.slice(offset, MAX_CHUNK_RECORDS)
-                    for offset in range(0, ordered.height, MAX_CHUNK_RECORDS)
-                )
-            assert sum(map(len, chunks)) == sum(map(len, sliced))
-            return sliced
+        if source.height <= MAX_CHUNK_RECORDS:
+            return [source]
+        ordered = source.sort(keys)
+        chunks = [
+            ordered.slice(offset, MAX_CHUNK_RECORDS)
+            for offset in range(0, ordered.height, MAX_CHUNK_RECORDS)
+        ]
+        assert sum(map(len, chunks)) == source.height
+        return chunks
 
     def _merge_apply(self, source: pl.DataFrame, keys: list[str], watermark: str) -> dict:
         """
@@ -1161,15 +1103,6 @@ class CubicODSDelta(OdinJob):
         assert not missing, (
             f"primary key columns {sorted(missing)} absent from silver table for {self.table}"
         )
-
-        if "odin_year" in source.columns:
-            inserts = source.filter(pl.col("odin_resolved_oper") == "I")
-            null_edw = inserts.get_column("edw_inserted_dtm").null_count()
-            assert null_edw == 0, (
-                f"{null_edw} insert-resolved CDC records for {self.table} carry a null "
-                "edw_inserted_dtm; inserted rows would land in the odin_year=0 "
-                "partition, which partition-pruned merges never revisit"
-            )
 
         passthrough = {"odin_snapshot", "header__change_seq"}
         partition_cols = {"odin_year", "odin_month"}
@@ -1199,7 +1132,7 @@ class CubicODSDelta(OdinJob):
         # Merge one partition at a time so delta-rs only rewrites a single
         # partition's files per MERGE, bounding peak memory.
         dt = self.silver
-        chunks = self._partition_chunks(source, keys)
+        chunks = self._merge_chunks(source, keys)
         totals: dict = {}
         for chunk in chunks:
             predicate = self._merge_predicate(keys, chunk)

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -21,8 +21,10 @@ a contents-derived watermark would regress and re-read that batch forever.
 
 The source data is treated as untrusted: every run asserts the invariants it
 depends on (required columns present, primary keys declared and present, CDC
-records carry a change sequence, and a load snapshot is non-empty). Violations
-raise rather than silently producing a corrupt silver table.
+records carry a change sequence, a load snapshot is non-empty, and — on
+year/month-partitioned tables — load and insert images carry a non-null
+``edw_inserted_dtm``). Violations raise rather than silently producing a corrupt
+silver table.
 
 Merges match on primary key alone and are cut into key-ordered chunks, never by
 partition, so a MERGE can always find its target row wherever it lives. File
@@ -30,8 +32,10 @@ selection is left to delta-rs, which derives a key-range filter from that
 predicate; the silver table is kept sorted by key so the filter prunes well.
 Partitioning by odin_year/odin_month remains for the reader layout and to bound
 reclustering, but it no longer participates in the merge — which is why a key
-whose ``edw_inserted_dtm`` changes, or a row that never had one, is now ordinary
-data rather than a hazard.
+whose ``edw_inserted_dtm`` changes is now ordinary data rather than a hazard.
+The null-``edw_inserted_dtm`` asserts above survive that change for a different
+reason: such rows are no longer unreachable, just undesirable, since odin_year=0
+collects rows with no date locality that every reclustering pass rewrites.
 
 Two Qlik Replicate behaviors are relied on without a runtime check:
   - ``header__change_seq`` is unique per change record, so paging with
@@ -482,15 +486,23 @@ class CubicODSDelta(OdinJob):
         """
         Assert the snapshot's "L" records can produce a valid silver table.
 
-        A null ``edw_inserted_dtm`` used to be rejected here: such a row landed in
-        the odin_year=0 partition, which a partition-pruned merge never reached.
-        Merges match on key alone now, so that partition is reachable like any
-        other and a table carrying null timestamps simply works.
+        Load images are expected to carry ``edw_inserted_dtm``; one without it lands
+        in the odin_year=0 partition. That is no longer a correctness problem — a
+        merge matching on key alone reaches that partition like any other — but it
+        is still a junk bucket: rows with no date locality that every reclustering
+        pass has to keep rewriting, and a signal that the feed has changed shape.
+
+        Checked before the overwrite, deliberately. A rebuild that scattered a
+        chunk of the table into odin_year=0 would stand until the next snapshot
+        rolls, which on these tables is a year away.
         """
+        checks = ["count(*)"]
+        if self.part_columns:
+            checks.append('count(*) FILTER (WHERE "edw_inserted_dtm" IS NULL)')
         row = (
             self._db()
             .execute(
-                f"SELECT count(*) FROM {self._read_history} "
+                f"SELECT {', '.join(checks)} FROM {self._read_history} "
                 "WHERE snapshot = ? AND header__change_oper = 'L'",
                 [self.history_snapshot],
             )
@@ -499,6 +511,12 @@ class CubicODSDelta(OdinJob):
         assert row is not None and row[0] > 0, (
             f"snapshot {self.history_snapshot} for {self.table} has no L (load) records"
         )
+        if self.part_columns:
+            assert row[1] == 0, (
+                f"snapshot {self.history_snapshot} for {self.table} has {row[1]} L (load) "
+                "records with a null edw_inserted_dtm; those rows would land in the "
+                "odin_year=0 partition"
+            )
 
     # ------------------------------------------------------------------
     # CDC MERGE (silver update from I/U/D records)
@@ -1103,6 +1121,19 @@ class CubicODSDelta(OdinJob):
         assert not missing, (
             f"primary key columns {sorted(missing)} absent from silver table for {self.table}"
         )
+
+        # "I" rows write their partition values verbatim, so one without an
+        # edw_inserted_dtm creates a row in odin_year=0 — see _check_load_records
+        # for why that bucket is unwanted even though it is now reachable. "U" rows
+        # are exempt: they keep the target's partition values (see update_set), so a
+        # sparse update to an existing row never moves it there.
+        if "odin_year" in source.columns:
+            inserts = source.filter(pl.col("odin_resolved_oper") == "I")
+            null_edw = inserts.get_column("edw_inserted_dtm").null_count()
+            assert null_edw == 0, (
+                f"{null_edw} insert-resolved CDC records for {self.table} carry a null "
+                "edw_inserted_dtm; inserted rows would land in the odin_year=0 partition"
+            )
 
         passthrough = {"odin_snapshot", "header__change_seq"}
         partition_cols = {"odin_year", "odin_month"}

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -483,19 +483,7 @@ class CubicODSDelta(OdinJob):
         log.complete(rows_loaded=delta_row_count(self.silver))
 
     def _check_load_records(self) -> None:
-        """
-        Assert the snapshot's "L" records can produce a valid silver table.
-
-        Load images are expected to carry ``edw_inserted_dtm``; one without it lands
-        in the odin_year=0 partition. That is no longer a correctness problem — a
-        merge matching on key alone reaches that partition like any other — but it
-        is still a junk bucket: rows with no date locality that every reclustering
-        pass has to keep rewriting, and a signal that the feed has changed shape.
-
-        Checked before the overwrite, deliberately. A rebuild that scattered a
-        chunk of the table into odin_year=0 would stand until the next snapshot
-        rolls, which on these tables is a year away.
-        """
+        """Assert the snapshot's "L" records can produce a valid silver table."""
         checks = ["count(*)"]
         if self.part_columns:
             checks.append('count(*) FILTER (WHERE "edw_inserted_dtm" IS NULL)')
@@ -1076,17 +1064,8 @@ class CubicODSDelta(OdinJob):
         _recluster_inserted_partitions), and the keys on these tables broadly track
         the partitioning column, so a key run maps onto a small set of files.
 
-        Chunking by partition instead produced a long tail of tiny merges — a batch
-        touching forty months paid forty commits, forty log replays and forty plans
-        to change a handful of rows each, and that fixed cost dominated the run.
-        Key ranges absorb those scattered rows into whichever run they fall in.
-
         No chunk carries a partition constraint, so every merge matches purely on
-        key and cannot miss a target row wherever it lives. That is what retires the
-        partition-immutability hazard: pruning is now delta-rs's business, and a
-        poorly-clustered table costs scan time rather than correctness. Partitioning
-        itself stays — it bounds reclustering and gives readers a dated layout — it
-        just no longer decides how the merge is cut.
+        key and cannot miss a target row wherever it lives.
         """
         if source.height <= MAX_CHUNK_RECORDS:
             return [source]
@@ -1122,11 +1101,6 @@ class CubicODSDelta(OdinJob):
             f"primary key columns {sorted(missing)} absent from silver table for {self.table}"
         )
 
-        # "I" rows write their partition values verbatim, so one without an
-        # edw_inserted_dtm creates a row in odin_year=0 — see _check_load_records
-        # for why that bucket is unwanted even though it is now reachable. "U" rows
-        # are exempt: they keep the target's partition values (see update_set), so a
-        # sparse update to an existing row never moves it there.
         if "odin_year" in source.columns:
             inserts = source.filter(pl.col("odin_resolved_oper") == "I")
             null_edw = inserts.get_column("edw_inserted_dtm").null_count()
@@ -1160,8 +1134,6 @@ class CubicODSDelta(OdinJob):
         }
         insert_set = {col: f'source."{col}"' for col in target_cols if col in source_cols}
 
-        # Merge one partition at a time so delta-rs only rewrites a single
-        # partition's files per MERGE, bounding peak memory.
         dt = self.silver
         chunks = self._merge_chunks(source, keys)
         totals: dict = {}

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -270,8 +270,8 @@ def test_merge_cdc_dated_table_derives_year_and_month(job):
     assert out.get_column("odin_month").to_list() == [1, 3]
 
 
-# Two partitions, each holding two keys whose ranges overlap the source key, so
-# only a partition constraint (not key-stat pruning) can skip a file.
+# Two partitions holding disjoint key ranges (1-2 and 3-4), the key-clustered
+# layout z_order maintains, so a narrow source key range can skip a whole file.
 def _two_partition_history() -> "pa.Table":
     from datetime import datetime
 
@@ -284,14 +284,14 @@ def _two_partition_history() -> "pa.Table":
                 "edw_inserted_dtm": datetime(2024, 1, 5),
             },
             {
-                "txn_id": 3,
-                "amount": 30,
+                "txn_id": 2,
+                "amount": 20,
                 "header__change_oper": "L",
                 "edw_inserted_dtm": datetime(2024, 1, 6),
             },
             {
-                "txn_id": 2,
-                "amount": 20,
+                "txn_id": 3,
+                "amount": 30,
                 "header__change_oper": "L",
                 "edw_inserted_dtm": datetime(2025, 3, 5),
             },
@@ -305,8 +305,15 @@ def _two_partition_history() -> "pa.Table":
     )
 
 
-def test_merge_prunes_untouched_partitions(job):
-    """A CDC update carrying edw_inserted_dtm skips files outside its partition."""
+def test_merge_prunes_by_key_range(job):
+    """
+    A merge skips files whose recorded key range cannot hold the source's keys.
+
+    This is the only pruning left: with no partition constraint, delta-rs derives
+    ``target.k BETWEEN min(source.k) AND max(source.k)`` from the key predicate
+    (under streamed_exec=False) and applies it to file selection. It pays only when
+    the target is key-clustered, which is what reclustering maintains.
+    """
     from datetime import datetime
 
     pipeline, write_history, _, _ = job
@@ -314,7 +321,7 @@ def test_merge_prunes_untouched_partitions(job):
     update = dated_history_rows(
         [
             {
-                "txn_id": 2,
+                "txn_id": 3,
                 "amount": 99,
                 "header__change_oper": "U",
                 "header__change_seq": "0001",
@@ -329,11 +336,11 @@ def test_merge_prunes_untouched_partitions(job):
     source = pipeline._build_merge_source(cdc_df, KEYS)
     metrics = pipeline._merge_apply(source, KEYS, "0001")
 
-    # The (2024, 1) file is skipped by the partition constraint, not key stats.
+    # The file holding keys 1-2 cannot contain key 3, so it is never read.
     assert metrics["num_target_files_skipped_during_scan"] >= 1
     out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table()).sort("txn_id")
     assert out.get_column("txn_id").to_list() == [1, 2, 3, 4]
-    assert out.filter(pl.col("txn_id") == 2).get_column("amount").to_list() == [99]
+    assert out.filter(pl.col("txn_id") == 3).get_column("amount").to_list() == [99]
 
 
 def test_read_cdc_keeps_tied_boundary_seqs_together(job):
@@ -361,53 +368,6 @@ def test_read_cdc_empty_when_caught_up(job):
         history_rows([{"txn_id": 1, "header__change_oper": "I", "header__change_seq": "0001"}])
     )
     assert pipeline._read_cdc("0005", limit=100).height == 0
-
-
-def test_partition_constraint_names_exact_pairs_not_cross_product(job):
-    """
-    The constraint names the (year, month) pairs the batch touches, not year x month.
-
-    Independent ``odin_year IN (...) AND odin_month IN (...)`` lists admit every
-    combination of the two, so a batch touching 2024-01 and 2025-03 would also drag
-    2024-03 and 2025-01 into the scan. Since the scan predicate is what bounds merge
-    memory, that cross product is the difference between scanning two partitions and
-    scanning dozens.
-    """
-    from datetime import datetime
-
-    pipeline, write_history, _, _ = job
-    base = _two_partition_history()
-    updates = dated_history_rows(
-        [
-            {
-                "txn_id": 1,
-                "amount": 11,
-                "header__change_oper": "U",
-                "header__change_seq": "0001",
-                "edw_inserted_dtm": datetime(2024, 1, 5),
-            },
-            {
-                "txn_id": 2,
-                "amount": 99,
-                "header__change_oper": "U",
-                "header__change_seq": "0002",
-                "edw_inserted_dtm": datetime(2025, 3, 5),
-            },
-        ]
-    )
-    write_history(pa.concat_tables([base, updates]))
-    pipeline._rebuild_silver()
-
-    cdc_df = pipeline._read_cdc("0", limit=100)
-    source = pipeline._build_merge_source(cdc_df, KEYS)
-    constraint = pipeline._partition_constraint(source)
-
-    assert "2024" in constraint and "2025" in constraint
-    # Both real pairs are named...
-    assert '"odin_year" = CAST(2024 AS INT) AND target."odin_month" = CAST(1 AS INT)' in constraint
-    assert '"odin_year" = CAST(2025 AS INT) AND target."odin_month" = CAST(3 AS INT)' in constraint
-    # ...and only those two, so the phantom 2024-03 / 2025-01 combinations are absent.
-    assert constraint.count("odin_year") == 2
 
 
 def test_merge_writes_stay_compressed(job):
@@ -512,8 +472,15 @@ def test_merge_cdc_releases_duckdb_before_merging(job):
     assert seen["con_open_during_merge"] is False
 
 
-def test_merge_no_prune_when_edw_missing(job):
-    """A CDC update missing edw_inserted_dtm falls back to an unpruned scan, still correct."""
+def test_merge_undated_update_prunes_on_key_alone(job):
+    """
+    A sparse update with no edw_inserted_dtm still prunes, because the key prunes.
+
+    This was the expensive case: with no timestamp the target partition was unknown,
+    so the merge ran unconstrained and scanned and rewrote the whole table. Pruning
+    comes from the key range now, which every CDC record carries by definition, so a
+    missing timestamp costs nothing.
+    """
     pipeline, write_history, _, _ = job
     base = _two_partition_history()
     update = dated_history_rows(
@@ -526,14 +493,11 @@ def test_merge_no_prune_when_edw_missing(job):
     source = pipeline._build_merge_source(cdc_df, KEYS)
     metrics = pipeline._merge_apply(source, KEYS, "0001")
 
-    # No partition constraint, and key ranges overlap, so no file can be skipped.
-    assert metrics["num_target_files_skipped_during_scan"] == 0
+    assert metrics["num_target_files_skipped_during_scan"] >= 1
     out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table()).sort("txn_id")
-    row2 = out.filter(pl.col("txn_id") == 2)
-    assert row2.get_column("amount").to_list() == [99]
-    # Partition preserved from the retained edw_inserted_dtm (not clobbered to 0).
-    assert row2.get_column("odin_year").to_list() == [2025]
-    assert row2.get_column("odin_month").to_list() == [3]
+    assert out.filter(pl.col("txn_id") == 2).get_column("amount").to_list() == [99]
+    # The row keeps the partition it already had rather than moving to odin_year=0.
+    assert out.filter(pl.col("txn_id") == 2).get_column("odin_year").to_list() == [2024]
 
 
 def test_rebuild_records_snapshot_and_initial_watermark(job):
@@ -660,13 +624,14 @@ def test_read_state_survives_an_interrupted_run(job):
     assert pipeline._read_state() == (TEST_SNAPSHOT, "0")
 
 
-def test_partition_changing_key_is_rejected_not_duplicated(job):
+def test_partition_changing_key_is_updated_not_duplicated(job):
     """
-    A key whose edw_inserted_dtm changes is caught rather than silently duplicated.
+    A key whose edw_inserted_dtm moves it between partitions is updated in place.
 
-    Each partition merge scans only its own partition, so a key whose target row
-    lives elsewhere is not seen and gets inserted alongside the old row. The batch
-    must be rejected instead.
+    This used to be rejected outright: a partition-scoped merge scanned only its own
+    partition, so a key whose target row lived elsewhere was never seen and got
+    inserted alongside the old row. Matching on key alone, the merge finds the row
+    wherever it is, and the partition change is just a row moving files.
     """
     from datetime import datetime
 
@@ -690,7 +655,7 @@ def test_partition_changing_key_is_rejected_not_duplicated(job):
                 "header__change_seq": "0001",
                 "edw_inserted_dtm": datetime(2024, 1, 5),
             },
-            # same key, different edw_inserted_dtm -> would move partitions
+            # same key, different edw_inserted_dtm -> moves partitions
             {
                 "txn_id": 1,
                 "amount": 12,
@@ -703,8 +668,13 @@ def test_partition_changing_key_is_rejected_not_duplicated(job):
     write_history(pa.concat_tables([base, cdc]))
     pipeline._rebuild_silver()
 
-    with pytest.raises(AssertionError, match="more than one edw_inserted_dtm"):
-        pipeline._merge_cdc("0")
+    pipeline._merge_cdc("0")
+
+    out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table())
+    assert out.height == 1  # one row, not the old one plus a duplicate
+    assert out.get_column("amount").to_list() == [12]
+    assert out.get_column("odin_year").to_list() == [2025]
+    assert out.get_column("odin_month").to_list() == [3]
 
 
 def test_delete_only_batch_advances_watermark(job):
@@ -771,8 +741,15 @@ def test_rebuild_silver_without_load_records_raises(job):
     assert read_silver().get_column("txn_id").to_list() == [7]
 
 
-def test_rebuild_silver_null_edw_on_partitioned_table_raises(job):
-    """On a partitioned table, an L record with a null edw_inserted_dtm raises pre-write."""
+def test_rebuild_silver_null_edw_lands_in_zero_partition(job):
+    """
+    On a partitioned table, an L record with a null edw_inserted_dtm is loaded.
+
+    It lands in odin_year=0, which used to be unreachable — a partition-pruned merge
+    never scanned it, so the row could never be updated again and the rebuild
+    rejected the snapshot outright. Merges match on key alone now, so that partition
+    is ordinary and a table carrying null timestamps just works.
+    """
     from datetime import datetime
 
     pipeline, write_history, _, _ = job
@@ -785,18 +762,25 @@ def test_rebuild_silver_null_edw_on_partitioned_table_raises(job):
                     "header__change_oper": "L",
                     "edw_inserted_dtm": datetime(2025, 1, 15),
                 },
-                # Null edw_inserted_dtm would land this row in the unreachable
-                # odin_year=0 partition.
                 {"txn_id": 2, "amount": 20, "header__change_oper": "L"},
             ]
         )
     )
-    with pytest.raises(AssertionError, match="edw_inserted_dtm"):
-        pipeline._rebuild_silver()
+    pipeline._rebuild_silver()
+
+    out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table()).sort("txn_id")
+    assert out.get_column("txn_id").to_list() == [1, 2]
+    assert out.get_column("odin_year").to_list() == [2025, 0]
 
 
-def test_merge_cdc_insert_with_null_edw_raises(job):
-    """On a partitioned table, an insertable CDC record with null edw_inserted_dtm raises."""
+def test_merge_cdc_reaches_row_in_the_zero_partition(job):
+    """
+    A null-edw row is insertable and remains updatable afterwards.
+
+    The insert asserts that used to guard odin_year=0 existed because a pruned merge
+    could never revisit it. This walks the full path the guard was protecting: insert
+    a row with no timestamp, then update it in a later batch and see the change land.
+    """
     from datetime import datetime
 
     pipeline, write_history, _, _ = job
@@ -809,20 +793,30 @@ def test_merge_cdc_insert_with_null_edw_raises(job):
                     "header__change_oper": "L",
                     "edw_inserted_dtm": datetime(2025, 1, 15),
                 },
-                # Full-image I record missing edw_inserted_dtm: inserting it would
-                # put the row in the unreachable odin_year=0 partition.
+                # Full-image I record with no edw_inserted_dtm -> odin_year=0.
                 {
                     "txn_id": 2,
                     "amount": 20,
                     "header__change_oper": "I",
                     "header__change_seq": "0001",
                 },
+                # ...and a later sparse update to that same row.
+                {
+                    "txn_id": 2,
+                    "amount": 99,
+                    "header__change_oper": "U",
+                    "header__change_seq": "0002",
+                },
             ]
         )
     )
     pipeline._rebuild_silver()
-    with pytest.raises(AssertionError, match="edw_inserted_dtm"):
-        pipeline._merge_cdc("0")
+    pipeline._merge_cdc("0")
+
+    out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table()).sort("txn_id")
+    assert out.get_column("txn_id").to_list() == [1, 2]
+    assert out.get_column("amount").to_list() == [10, 99]  # the 0-partition row updated
+    assert out.get_column("odin_year").to_list() == [2025, 0]
 
 
 def test_merge_cdc_insert_adds_new_key(job):
@@ -1338,7 +1332,6 @@ def test_partition_metrics_reports_touched_partitions(job):
     assert metrics == {
         "partitions_touched": 2,
         "partition_rows": "2024-01=2,2025-03=1",
-        "partition_scan_pruned": True,
     }
 
 
@@ -1357,7 +1350,6 @@ def test_partition_metrics_counts_unknown_partition_rows(job):
     metrics = pipeline._partition_metrics(source)
     assert metrics["partitions_touched"] == 1
     assert metrics["partition_rows"] == "2025-03=1"
-    assert metrics["partition_scan_pruned"] is False
     assert metrics["partition_rows_unknown"] == 1
 
 
@@ -1751,20 +1743,25 @@ def dated_chunk_rows(txn_ids: list[int], year: int, month: int) -> list[dict]:
     ]
 
 
-def test_partition_chunks_leaves_small_chunks_whole(job):
-    """Under the size limit, chunking is still one frame per partition."""
+def test_merge_chunks_ignores_partitions(job):
+    """
+    Under the size limit the whole source is one chunk, however many partitions.
+
+    Chunking by partition produced a long tail of tiny merges, each paying a commit,
+    a log replay and a plan to change a handful of rows. Rows spread across two
+    months merge together now.
+    """
     pipeline, _, _, _ = job
     source = chunk_source(dated_chunk_rows([3, 1, 2], 2025, 1) + dated_chunk_rows([4], 2025, 3))
 
-    chunks = pipeline._partition_chunks(source, KEYS)
+    chunks = pipeline._merge_chunks(source, KEYS)
 
-    assert sorted(chunk.height for chunk in chunks) == [1, 3]
+    assert [chunk.height for chunk in chunks] == [4]
     # No reordering when nothing needs slicing.
-    big = next(chunk for chunk in chunks if chunk.height == 3)
-    assert big.get_column("txn_id").to_list() == [3, 1, 2]
+    assert chunks[0].get_column("txn_id").to_list() == [3, 1, 2, 4]
 
 
-def test_partition_chunks_slices_oversized_chunk_in_key_order(job):
+def test_merge_chunks_slices_oversized_chunk_in_key_order(job):
     """
     An oversized chunk is cut into contiguous runs of keys, not arbitrary slices.
 
@@ -1779,7 +1776,7 @@ def test_partition_chunks_slices_oversized_chunk_in_key_order(job):
     txn_ids = [((i * 7919) % (limit * 2 + 1)) for i in range(limit * 2 + 1)]
     source = chunk_source(dated_chunk_rows(txn_ids, 2025, 1))
 
-    chunks = pipeline._partition_chunks(source, KEYS)
+    chunks = pipeline._merge_chunks(source, KEYS)
 
     assert [chunk.height for chunk in chunks] == [limit, limit, 1]
     # Every slice is a contiguous run, so the ranges are disjoint and ascending.
@@ -1792,8 +1789,8 @@ def test_partition_chunks_slices_oversized_chunk_in_key_order(job):
     assert sorted(k for chunk in chunks for k in chunk.get_column("txn_id")) == sorted(txn_ids)
 
 
-def test_partition_chunks_slices_undated_rows_too(job):
-    """The unknown-partition rows are chunked by the same rule as everything else."""
+def test_merge_chunks_slices_undated_rows_too(job):
+    """Rows with no edw_inserted_dtm are chunked by the same rule as everything else."""
     pipeline, _, _, _ = job
     limit = delta_ods.MAX_CHUNK_RECORDS
     source = chunk_source(
@@ -1803,22 +1800,21 @@ def test_partition_chunks_slices_undated_rows_too(job):
         ]
     )
 
-    chunks = pipeline._partition_chunks(source, KEYS)
+    chunks = pipeline._merge_chunks(source, KEYS)
 
     assert [chunk.height for chunk in chunks] == [limit, 5]
-    # Still unconstrained (null edw), so each slice merges against every partition —
-    # but against a narrow key range, which is what lets file skipping help.
-    assert pipeline._partition_constraint(chunks[0]) == ""
+    # Nothing special is done for them any more: they are keyed and sliced like the
+    # rest, and merge against a narrow key range rather than an unpruned whole table.
     assert chunks[0].get_column("txn_id").to_list() == sorted(chunks[0].get_column("txn_id"))
 
 
-def test_partition_chunks_unpartitioned_table_still_sliced(job):
+def test_merge_chunks_unpartitioned_table_still_sliced(job):
     """A table with no partition columns starts as one chunk and is cut by size."""
     pipeline, _, _, _ = job
     limit = delta_ods.MAX_CHUNK_RECORDS
     source = pl.DataFrame({"txn_id": list(reversed(range(limit + 1)))}, schema={"txn_id": pl.Int64})
 
-    chunks = pipeline._partition_chunks(source, KEYS)
+    chunks = pipeline._merge_chunks(source, KEYS)
 
     assert [chunk.height for chunk in chunks] == [limit, 1]
     assert chunks[0].get_column("txn_id").to_list() == sorted(chunks[0].get_column("txn_id"))

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -741,15 +741,8 @@ def test_rebuild_silver_without_load_records_raises(job):
     assert read_silver().get_column("txn_id").to_list() == [7]
 
 
-def test_rebuild_silver_null_edw_lands_in_zero_partition(job):
-    """
-    On a partitioned table, an L record with a null edw_inserted_dtm is loaded.
-
-    It lands in odin_year=0, which used to be unreachable — a partition-pruned merge
-    never scanned it, so the row could never be updated again and the rebuild
-    rejected the snapshot outright. Merges match on key alone now, so that partition
-    is ordinary and a table carrying null timestamps just works.
-    """
+def test_rebuild_silver_null_edw_on_partitioned_table_raises(job):
+    """On a partitioned table, an L record with a null edw_inserted_dtm raises pre-write."""
     from datetime import datetime
 
     pipeline, write_history, _, _ = job
@@ -762,25 +755,17 @@ def test_rebuild_silver_null_edw_lands_in_zero_partition(job):
                     "header__change_oper": "L",
                     "edw_inserted_dtm": datetime(2025, 1, 15),
                 },
+                # Null edw_inserted_dtm would land this row in the odin_year=0 bucket.
                 {"txn_id": 2, "amount": 20, "header__change_oper": "L"},
             ]
         )
     )
-    pipeline._rebuild_silver()
-
-    out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table()).sort("txn_id")
-    assert out.get_column("txn_id").to_list() == [1, 2]
-    assert out.get_column("odin_year").to_list() == [2025, 0]
+    with pytest.raises(AssertionError, match="edw_inserted_dtm"):
+        pipeline._rebuild_silver()
 
 
-def test_merge_cdc_reaches_row_in_the_zero_partition(job):
-    """
-    A null-edw row is insertable and remains updatable afterwards.
-
-    The insert asserts that used to guard odin_year=0 existed because a pruned merge
-    could never revisit it. This walks the full path the guard was protecting: insert
-    a row with no timestamp, then update it in a later batch and see the change land.
-    """
+def test_merge_cdc_insert_with_null_edw_raises(job):
+    """On a partitioned table, an insertable CDC record with null edw_inserted_dtm raises."""
     from datetime import datetime
 
     pipeline, write_history, _, _ = job
@@ -793,30 +778,83 @@ def test_merge_cdc_reaches_row_in_the_zero_partition(job):
                     "header__change_oper": "L",
                     "edw_inserted_dtm": datetime(2025, 1, 15),
                 },
-                # Full-image I record with no edw_inserted_dtm -> odin_year=0.
+                # Full-image I record missing edw_inserted_dtm: inserting it would
+                # put the row in the odin_year=0 bucket.
                 {
                     "txn_id": 2,
                     "amount": 20,
                     "header__change_oper": "I",
                     "header__change_seq": "0001",
                 },
-                # ...and a later sparse update to that same row.
-                {
-                    "txn_id": 2,
-                    "amount": 99,
-                    "header__change_oper": "U",
-                    "header__change_seq": "0002",
-                },
             ]
         )
     )
     pipeline._rebuild_silver()
+    with pytest.raises(AssertionError, match="edw_inserted_dtm"):
+        pipeline._merge_cdc("0")
+
+
+def test_merge_cdc_reaches_a_row_already_in_the_zero_partition(job):
+    """
+    A row that is already in odin_year=0 can still be updated.
+
+    The asserts above keep new ones from being created, but a table built before
+    they existed may already hold some. This writes one directly, bypassing them, to
+    confirm the old trap is gone: a partition-pruned merge could never revisit that
+    partition, so such a row was stranded permanently. Matching on key alone reaches
+    it like any other.
+    """
+    pipeline, write_history, _, _ = job
+    write_history(
+        dated_history_rows(
+            [
+                {
+                    "txn_id": 2,
+                    "amount": 99,
+                    "header__change_oper": "U",
+                    "header__change_seq": "0001",
+                }
+            ]
+        )
+    )
+    pipeline.part_columns = ["odin_year", "odin_month"]
+    write_deltalake(
+        pipeline.silver_uri,
+        pa.Table.from_pylist(
+            [
+                {
+                    "txn_id": 2,
+                    "amount": 20,
+                    "status": None,
+                    "header__change_seq": None,
+                    "odin_snapshot": TEST_SNAPSHOT,
+                    "edw_inserted_dtm": None,
+                    "odin_year": 0,
+                    "odin_month": 0,
+                }
+            ],
+            schema=pa.schema(
+                list(SILVER_SCHEMA)
+                + [
+                    pa.field("edw_inserted_dtm", pa.timestamp("us")),
+                    pa.field("odin_year", pa.int32()),
+                    pa.field("odin_month", pa.int32()),
+                ]
+            ),
+        ),
+        mode="overwrite",
+        schema_mode="overwrite",
+        partition_by=["odin_year", "odin_month"],
+    )
+    pipeline.silver = DeltaTable(pipeline.silver_uri)
+
     pipeline._merge_cdc("0")
 
-    out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table()).sort("txn_id")
-    assert out.get_column("txn_id").to_list() == [1, 2]
-    assert out.get_column("amount").to_list() == [10, 99]  # the 0-partition row updated
-    assert out.get_column("odin_year").to_list() == [2025, 0]
+    out = pl.from_arrow(DeltaTable(pipeline.silver_uri).to_pyarrow_table())
+    # 99, not the pre-existing 20: the merge matched rather than dropping the update
+    # as an orphan, which is exactly what the old partition-pruned merge did here.
+    assert out.get_column("amount").to_list() == [99]
+    assert out.get_column("odin_year").to_list() == [0]  # stays put, but was reached
 
 
 def test_merge_cdc_insert_adds_new_key(job):


### PR DESCRIPTION
Delta fact table development has taken a couple of turns:

- The original implementation included year- and month-based partitioning (`odin_year` and `odin_month` columns), based on values parsed from `edw_inserted_dtm`, and used that split out merge operations by part. (Only for tables which include edw_inserted_dtm, but this seemed to be most frequently-updated tables.)
- It turned out that some frequently-updated had a edw_inserted_dtm, but let this be null in ~all update operations, meaning that merging these updates could not be targeted via odin_year/odin_month. This meant those merges had to open many fact table files, which is memory-intensive and lead to OOM errors.
- Last week I implemented z_order()-based sorting to sort all files by the primary key, which (for all tables examined so far) sorts along date. This meant that un-dated updates can be sorted by key, batched, and then each batch only targets a particular slice of fact table files, leading to much better memory performance.
- This renders partition-based merging obsolete; the current pattern is for an update to include several MAX_CHUNK_RECORDS-sized merge() batches of un-dated rows, followed by a large number of very small batches of dated rows targeted to various partitions. The latter could be consolidated into a single batch, saving time, by simply dropping the odin_year/odin_month batching.

This change should make the code simpler, remove a failure case (incorrect partition targeting,) and increase speed on some tables. Worth noting; partitions are still used, since the z_order() sorting works partition-by-partition. 