### PR TITLE
Enable legacy fact job on gamma for DEVICE_LAST_STATE

### DIFF
--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -76,6 +76,9 @@ def start():
     if odin_instance in ["alpha", "beta", "gamma", "delta"]:
         schedule_cubic_archive_qlik(schedule)
 
+    if odin_instance in ["gamma"]:
+        schedule_cubic_ods_fact_gen(schedule)
+
     if odin_instance in ["alpha", "beta"]:
         schedule_cubic_ods_fact_gen(schedule)
         schedule_delta_ods(schedule)

--- a/src/odin/run.py
+++ b/src/odin/run.py
@@ -75,12 +75,9 @@ def start():
     schedule_sigterm_check(schedule)
     if odin_instance in ["alpha", "beta", "gamma", "delta"]:
         schedule_cubic_archive_qlik(schedule)
-
-    if odin_instance in ["gamma"]:
         schedule_cubic_ods_fact_gen(schedule)
 
     if odin_instance in ["alpha", "beta"]:
-        schedule_cubic_ods_fact_gen(schedule)
         schedule_delta_ods(schedule)
         schedule_masabi_archive(schedule)
         schedule_afc_archive(schedule)


### PR DESCRIPTION
Intended to have DEVICE_LAST_STATE legacy fact job run on gamma to catch up, since it's pretty clear the delta table won't anytime soon, but forgot to enable the job on that instance.