### PR TITLE
fix: removing false positive BEHIND for tables with only recent deletes

### DIFF
--- a/scripts/get_table_status.py
+++ b/scripts/get_table_status.py
@@ -174,6 +174,9 @@ def is_behind(payload: dict, lag_seconds: float) -> bool:
     jobs_lag = payload.get("jobs_lag")  # AFC
     if isinstance(jobs_lag, int) and jobs_lag > 0:
         return True
+    pending = payload.get("cdc_records_pending")
+    if isinstance(pending, int) and pending == 0 and payload.get("cdc_budget_nearly_full") is False:
+        return False
     # Secondary: a true backlog (seq lag, not clock lag) beyond the threshold.
     seq_lag = payload.get("seq_lag_seconds")
     if isinstance(seq_lag, (int, float)) and seq_lag > lag_seconds:


### PR DESCRIPTION
Certain tables (especially `UNSETTLED_*` tables) were showing up as behind in ODS in the table status report, sometimes by large margins, because the fact table did not include recent rows present in the history. This change now adds a check for the number of pending rows from the last run, and whether the row budget was full. For these tables, the pending rows has consistently been 0 after each run, and the row budget was far from full.

Tested and verified that the false positives no longer show up.