### PR TITLE
feat: adding workflow to post status to Slack

### DIFF
--- a/.github/workflows/table_status_report.yaml
+++ b/.github/workflows/table_status_report.yaml
@@ -61,6 +61,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           DATA_SPRINGBOARD: mbta-ctd-dataplatform-springboard
           PYTHONPATH: src
+          ODIN_INSTANCE: alpha
         run: |
           python scripts/get_table_status.py \
             --slack \

--- a/.github/workflows/table_status_report.yaml
+++ b/.github/workflows/table_status_report.yaml
@@ -1,0 +1,69 @@
+name: Table Status Report
+
+# Posts the Odin per-table freshness summary to Slack once a day.
+#
+# The report is never written to this job's log: `get_table_status.py --slack` captures
+# its own stdout and POSTs it to the webhook. mbta/odin is a public repository, so job
+# logs are world-readable
+
+on:
+  schedule:
+    # 12:00 UTC daily (08:00 ET in summer, 07:00 ET in winter)
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+    inputs:
+      detailed:
+        description: Include a line for every table, OK ones included
+        type: boolean
+        default: false
+      stale_hours:
+        description: No run within this many hours counts as stale
+        type: string
+        default: '24'
+      lag_hours:
+        description: Backlog over this many hours counts as behind
+        type: string
+        default: '4'
+
+concurrency:
+  group: table-status-report
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Report Table Status
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      # The status script only touches S3 via odin.utils.aws.s3, so it needs boto3 and
+      # psutil, not the full requirements.txt
+      - name: Install Dependencies
+        run: pip install boto3 psutil
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Post Status Report to Slack
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          DATA_SPRINGBOARD: mbta-ctd-dataplatform-springboard
+          PYTHONPATH: src
+        run: |
+          python scripts/get_table_status.py \
+            --slack \
+            --stale-hours "${{ inputs.stale_hours || '24' }}" \
+            --lag-hours "${{ inputs.lag_hours || '4' }}" \
+            ${{ inputs.detailed && '--detailed' || '' }}

--- a/scripts/get_table_status.py
+++ b/scripts/get_table_status.py
@@ -33,14 +33,20 @@ Usage:
     python scripts/get_table_status.py                      # overall summary (hides OK tables)
     python scripts/get_table_status.py --detailed           # include info for OK tables
     python scripts/get_table_status.py --group ODS --table EDW.SALE_TRANSACTION # table details
+    python scripts/get_table_status.py --slack              # post to Slack using $SLACK_WEBHOOK
+    python scripts/get_table_status.py --slack-test         # preview Slack message, post nothing
 """
 
 import argparse
+import contextlib
+import io
 import json
 import logging
 import os
 import sys
 import tempfile
+import urllib.error
+import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -83,6 +89,17 @@ DEFAULT_LAG_HOURS = 4.0
 # connection pool is sized well above this.
 MAX_FETCH_WORKERS = 16
 
+# Webhook URL == credential for posting to Slack
+# Ensure it never is passed in plain text, or makes it to error messages
+SLACK_WEBHOOK_ENV = "SLACK_WEBHOOK"
+
+# Slack `text` field accepts max 40,000 characters, truncate to fit if
+# necessary.
+# Not expecting to see this limit hit: --detailed view as of 2026-08-12 is
+# displaying about 20k characters, and most status reports will be ~1k
+SLACK_TEXT_LIMIT = 40000
+TRUNCATION_NOTICE = "\n[truncated: report exceeded Slack's 40,000 character limit]"
+
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
@@ -119,9 +136,7 @@ def _fmt_count(value: Any) -> str:
 
 
 def fetch_group(prefix: str, tmpdir: str, only: Optional[set[str]] = None) -> dict[str, dict]:
-    """
-    Download status objects under `prefix`; return {table: payload}
-    """
+    """Download status objects under `prefix`; return {table: payload}"""
     objects = list_objects(f"{DATA_SPRINGBOARD}/{prefix}/", in_filter=".json")
     wanted = [(os.path.basename(obj.path)[: -len(".json")], obj.path) for obj in objects]
     if only is not None:
@@ -339,7 +354,7 @@ def print_overall(
     When `detailed`, every table gets a per-table line (OK tables included, with a
     key-info summary); otherwise only not-OK tables are listed.
     """
-    print(f"Odin table status  --  {now.strftime('%Y-%m-%dT%H:%MZ')}")
+    print(f"Fares table status: {now.strftime('%Y-%m-%dT%H:%MZ')}")
 
     print("\nKey:")
     print(
@@ -392,6 +407,58 @@ def print_overall(
     return problems
 
 
+def _fit_to_slack_limit(report: str, overhead: int) -> str:
+    budget = SLACK_TEXT_LIMIT - overhead
+    if len(report) <= budget:
+        return report
+    keep = max(budget - len(TRUNCATION_NOTICE), 0)
+    return report[:keep].rstrip() + TRUNCATION_NOTICE
+
+
+def _slack_post(webhook: str, payload: dict) -> None:
+    """
+    POST one message to `webhook`, raising RuntimeError with no URL in the message.
+
+    urllib puts the request URL into HTTPError's string form, so failures are re-raised
+    with only the status and Slack's error string ("invalid_payload", "no_service", ...).
+    Letting the original propagate would print the webhook into a public CI log.
+    """
+    request = urllib.request.Request(
+        webhook,
+        json.dumps(payload).encode("utf-8"),
+        {"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read().decode("utf-8", "replace").strip()
+        if body != "ok":
+            raise RuntimeError(f"Slack returned an unexpected body: {body!r}")
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", "replace").strip()
+        raise RuntimeError(f"Slack rejected the message: HTTP {error.code} {detail}") from None
+    except urllib.error.URLError as error:
+        raise RuntimeError(f"Could not reach Slack: {error.reason}") from None
+
+
+def build_slack_message(report: str, problems: int) -> str:
+    """Add header to status body, which can optionally contain emojis (including mbta ones)"""
+    if problems:
+        lead = f":mbta_bus_intensifies: *Fares table status*: {problems} table(s) behind or stale"
+    else:
+        lead = ":white_check_mark: *Fares table status*: all tables OK"
+
+    # The fence and the lead-in count against Slack's cap along with the report.
+    prefix = f"{lead}\n```\n"
+    suffix = "\n```"
+    body = _fit_to_slack_limit(report, len(prefix) + len(suffix))
+    return f"{prefix}{body}{suffix}"
+
+
+def post_report_to_slack(message: str, webhook: str) -> None:
+    """Post an already-rendered message to Slack as text"""
+    _slack_post(webhook, {"text": message})
+
+
 def main() -> int:
     """Parse args and dispatch to the single-table or overall view."""
     parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0] if __doc__ else None)
@@ -420,10 +487,40 @@ def main() -> int:
         action="store_true",
         help="keep Odin's per-S3-call INFO logging (suppressed by default)",
     )
+    parser.add_argument(
+        "--slack",
+        action="store_true",
+        help=(
+            "post the summary to Slack rather than printing it; the webhook URL is read "
+            f"from ${SLACK_WEBHOOK_ENV}. Exit status then reports whether the report was "
+            "delivered, not whether the tables are healthy"
+        ),
+    )
+    parser.add_argument(
+        "--slack-test",
+        action="store_true",
+        help=(
+            "render the Slack message and print it here instead of posting; needs no "
+            f"${SLACK_WEBHOOK_ENV} and contacts Slack not at all"
+        ),
+    )
+    parser.add_argument(
+        "--only-if-problems",
+        action="store_true",
+        help="with --slack, post nothing when every table is OK",
+    )
     args = parser.parse_args()
+
+    slack_mode = args.slack or args.slack_test
 
     if args.table and not args.group:
         parser.error("--table requires --group")
+
+    if slack_mode and (args.json or args.table):
+        parser.error("--slack applies to the overall/group view, not to --json or --table")
+
+    if args.only_if_problems and not slack_mode:
+        parser.error("--only-if-problems requires --slack or --slack-test")
 
     # The S3 helpers log an INFO line per list/download via Odin's shared logger, which
     # would bury this summary. Quiet that logger unless --verbose is asked for; leave the
@@ -455,6 +552,46 @@ def main() -> int:
             for group in groups:
                 out[group] = fetch_group(GROUPS[group]["prefix"], tmpdir)
         print(json.dumps(out, indent=2))
+        return 0
+
+    if slack_mode:
+        # --slack-test never contacts Slack, so it must not require the credential.
+        webhook = os.environ.get(SLACK_WEBHOOK_ENV, "").strip()
+        if not webhook and not args.slack_test:
+            print(f"{SLACK_WEBHOOK_ENV} is unset; cannot post to Slack.", file=sys.stderr)
+            return 1
+
+        # Capture the report instead of printing it. On a public repo the CI job log is
+        # world-readable, so the summary should reach Slack without passing through stdout.
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            problems = print_overall(groups, now, stale_seconds, lag_seconds, args.detailed)
+
+        if problems == 0 and args.only_if_problems:
+            if args.slack_test:
+                print("Every table is OK; --only-if-problems would post nothing.", file=sys.stderr)
+            return 0
+
+        message = build_slack_message(buffer.getvalue().strip(), problems)
+
+        if args.slack_test:
+            # The message goes to stdout so it can be piped or diffed; the size note goes
+            # to stderr so it never pollutes that output. Flush first, or the note (on
+            # unbuffered stderr) jumps ahead of the message when stdout is piped.
+            print(message, flush=True)
+            truncated = TRUNCATION_NOTICE.strip() in message
+            note = f"{len(message):,} of {SLACK_TEXT_LIMIT:,} characters"
+            print(
+                f"\n[--slack-test: not posted; {note}{'; TRUNCATED' if truncated else ''}]",
+                file=sys.stderr,
+            )
+            return 0
+
+        try:
+            post_report_to_slack(message, webhook)
+        except RuntimeError as error:
+            print(str(error), file=sys.stderr)
+            return 1
         return 0
 
     return 1 if print_overall(groups, now, stale_seconds, lag_seconds, args.detailed) else 0

--- a/scripts/get_table_status.py
+++ b/scripts/get_table_status.py
@@ -64,11 +64,15 @@ from odin.utils.logger import LOGGER_NAME
 GROUPS: dict[str, dict[str, Any]] = {
     "ODS": {
         "prefix": CUBIC_ODS_FACT_STATUS,
-        "tables": ("odin.ingestion.qlik.tables", "CUBIC_ODS_TABLES_INSTANCE"),
+        "tables": ("odin.ingestion.qlik.tables", "CUBIC_ODS_TABLES"),
     },
     "delta_ODS": {
+        # CUBIC_ODS_DELTA_TABLES only lists the tables belonging to whichever instance
+        # this process resolves to, but the status prefix holds every instance's objects.
+        # Read the manifest directly so the expected list covers all of them.
         "prefix": CUBIC_ODS_DELTA_STATUS,
-        "tables": ("odin.ingestion.qlik.tables", "CUBIC_ODS_DELTA_TABLES_INSTANCE"),
+        "tables": ("odin.ingestion.qlik.tables", "TABLE_MANIFEST"),
+        "manifest_index": "DELTA_FACT_JOB_IND",
     },
     "AFC": {
         "prefix": AFC_STATUS,
@@ -91,7 +95,7 @@ MAX_FETCH_WORKERS = 16
 
 # Webhook URL == credential for posting to Slack
 # Ensure it never is passed in plain text, or makes it to error messages
-SLACK_WEBHOOK_ENV = "SLACK_WEBHOOK"
+SLACK_WEBHOOK = os.environ.get("SLACK_WEBHOOK", "").strip()
 
 # Slack `text` field accepts max 40,000 characters, truncate to fit if
 # necessary.
@@ -165,9 +169,16 @@ def fetch_group(prefix: str, tmpdir: str, only: Optional[set[str]] = None) -> di
 def expected_tables(group: str) -> list[str]:
     """Best-effort import of a group's configured table list; [] if unavailable."""
     module_path, attr = GROUPS[group]["tables"]
+    index_name = GROUPS[group].get("manifest_index")
     try:
         module = __import__(module_path, fromlist=[attr])
-        return list(getattr(module, attr))
+        configured = getattr(module, attr)
+        if index_name is None:
+            return list(configured)
+        # TABLE_MANIFEST maps table -> per-job instance assignment, None where that job
+        # does not run for the table. Taking every non-None entry covers all instances.
+        index = getattr(module, index_name)
+        return [table for table, jobs in configured.items() if jobs[index] is not None]
     except Exception:  # noqa: BLE001 - the list is a nicety, not a requirement
         return []
 
@@ -347,9 +358,9 @@ def print_overall(
     stale_seconds: float,
     lag_seconds: float,
     detailed: bool = False,
-) -> int:
+) -> tuple[int, int]:
     """
-    Print the summary for `groups`; return the count of not-OK tables.
+    Print the summary for `groups`; return (not-OK table count, total tables seen).
 
     When `detailed`, every table gets a per-table line (OK tables included, with a
     key-info summary); otherwise only not-OK tables are listed.
@@ -404,7 +415,7 @@ def print_overall(
 
     problems = total_behind + total_stale
     print(f"Summary: {total_behind} behind, {total_stale} stale across {total_tables} tables.")
-    return problems
+    return problems, total_tables
 
 
 def _fit_to_slack_limit(report: str, overhead: int) -> str:
@@ -417,33 +428,45 @@ def _fit_to_slack_limit(report: str, overhead: int) -> str:
 
 def _slack_post(webhook: str, payload: dict) -> None:
     """
-    POST one message to `webhook`, raising RuntimeError with no URL in the message.
+    POST one message to `webhook`; every failure becomes a RuntimeError with no URL in it
 
-    urllib puts the request URL into HTTPError's string form, so failures are re-raised
-    with only the status and Slack's error string ("invalid_payload", "no_service", ...).
-    Letting the original propagate would print the webhook into a public CI log.
+    Anything urllib raises (rejection, unreachable host, read timeout, malformed URL)
+    is reported the same way, so the caller has one exception type to catch and no failure
+    mode can escape as a traceback out of a scheduled job.
     """
-    request = urllib.request.Request(
-        webhook,
-        json.dumps(payload).encode("utf-8"),
-        {"Content-Type": "application/json"},
-    )
     try:
+        # Built inside the try: a webhook missing its https:// scheme raises here, not
+        # at urlopen.
+        request = urllib.request.Request(
+            webhook,
+            json.dumps(payload).encode("utf-8"),
+            {"Content-Type": "application/json"},
+        )
         with urllib.request.urlopen(request, timeout=30) as response:
             body = response.read().decode("utf-8", "replace").strip()
-        if body != "ok":
-            raise RuntimeError(f"Slack returned an unexpected body: {body!r}")
     except urllib.error.HTTPError as error:
-        detail = error.read().decode("utf-8", "replace").strip()
-        raise RuntimeError(f"Slack rejected the message: HTTP {error.code} {detail}") from None
-    except urllib.error.URLError as error:
-        raise RuntimeError(f"Could not reach Slack: {error.reason}") from None
+        # Slack names the reason in the body: invalid_payload/no_service/no_text
+        detail = f"HTTP {error.code} {error.read().decode('utf-8', 'replace').strip()}"
+    except Exception as error:  # noqa: BLE001 - report every failure the same way
+        detail = f"{type(error).__name__}: {error}"
+    else:
+        if body == "ok":
+            return
+        detail = f"unexpected response body {body!r}"
+
+    # Scrub before raising: a webhook stored without its https:// scheme comes back
+    # inside ValueError's message, and this repo's CI logs are public.
+    raise RuntimeError(f"Could not post to Slack: {detail}".replace(webhook, "<webhook>"))
 
 
-def build_slack_message(report: str, problems: int) -> str:
+def build_slack_message(report: str, problems: int, total_tables: int) -> str:
     """Add header to status body, which can optionally contain emojis (including mbta ones)"""
-    if problems:
-        lead = f":mbta_bus_intensifies: *Fares table status*: {problems} table(s) behind or stale"
+    if total_tables == 0:
+        # Seeing no tables at all is most likely a failure to read:
+        # list_objects swallows AccessDenied/NoSuchBucket and returns an empty list.
+        lead = ":rotating_light: *Fares table status*: NO DATA. Could not read any status objects"
+    elif problems:
+        lead = f":warning: *Fares table status*: {problems} table(s) behind or stale"
     else:
         lead = ":white_check_mark: *Fares table status*: all tables OK"
 
@@ -452,11 +475,6 @@ def build_slack_message(report: str, problems: int) -> str:
     suffix = "\n```"
     body = _fit_to_slack_limit(report, len(prefix) + len(suffix))
     return f"{prefix}{body}{suffix}"
-
-
-def post_report_to_slack(message: str, webhook: str) -> None:
-    """Post an already-rendered message to Slack as text"""
-    _slack_post(webhook, {"text": message})
 
 
 def main() -> int:
@@ -492,7 +510,7 @@ def main() -> int:
         action="store_true",
         help=(
             "post the summary to Slack rather than printing it; the webhook URL is read "
-            f"from ${SLACK_WEBHOOK_ENV}. Exit status then reports whether the report was "
+            "from $SLACK_WEBHOOK. Exit status then reports whether the report was "
             "delivered, not whether the tables are healthy"
         ),
     )
@@ -501,7 +519,7 @@ def main() -> int:
         action="store_true",
         help=(
             "render the Slack message and print it here instead of posting; needs no "
-            f"${SLACK_WEBHOOK_ENV} and contacts Slack not at all"
+            "$SLACK_WEBHOOK and contacts Slack not at all"
         ),
     )
     parser.add_argument(
@@ -556,23 +574,26 @@ def main() -> int:
 
     if slack_mode:
         # --slack-test never contacts Slack, so it must not require the credential.
-        webhook = os.environ.get(SLACK_WEBHOOK_ENV, "").strip()
-        if not webhook and not args.slack_test:
-            print(f"{SLACK_WEBHOOK_ENV} is unset; cannot post to Slack.", file=sys.stderr)
+        if not SLACK_WEBHOOK and not args.slack_test:
+            print("SLACK_WEBHOOK is unset; cannot post to Slack.", file=sys.stderr)
             return 1
 
         # Capture the report instead of printing it. On a public repo the CI job log is
         # world-readable, so the summary should reach Slack without passing through stdout.
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
-            problems = print_overall(groups, now, stale_seconds, lag_seconds, args.detailed)
+            problems, total_tables = print_overall(
+                groups, now, stale_seconds, lag_seconds, args.detailed
+            )
 
-        if problems == 0 and args.only_if_problems:
+        # A read that turned up nothing is always worth reporting, even under
+        # --only-if-problems: silence there would look identical to a healthy day.
+        if problems == 0 and total_tables > 0 and args.only_if_problems:
             if args.slack_test:
                 print("Every table is OK; --only-if-problems would post nothing.", file=sys.stderr)
             return 0
 
-        message = build_slack_message(buffer.getvalue().strip(), problems)
+        message = build_slack_message(buffer.getvalue().strip(), problems, total_tables)
 
         if args.slack_test:
             # The message goes to stdout so it can be piped or diffed; the size note goes
@@ -588,13 +609,15 @@ def main() -> int:
             return 0
 
         try:
-            post_report_to_slack(message, webhook)
+            _slack_post(SLACK_WEBHOOK, {"text": message})
         except RuntimeError as error:
             print(str(error), file=sys.stderr)
             return 1
-        return 0
+        # No tables indicates a problem regardless
+        return 1 if total_tables == 0 else 0
 
-    return 1 if print_overall(groups, now, stale_seconds, lag_seconds, args.detailed) else 0
+    problems, total_tables = print_overall(groups, now, stale_seconds, lag_seconds, args.detailed)
+    return 1 if problems or total_tables == 0 else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds ability to post status updates to slack via a webhook, and adds an action to run every day at 12:00 UTC daily (08:00 ET in summer, 07:00 ET in winter) via cron. Importantly, this does not expose the webhook url, even in cases of errors, nor does it expose status logs, which are ported directly to the webhook.