### PR TITLE
Add checkpointing to delta table update

### DIFF
--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -254,6 +254,7 @@ class CubicODSDelta(OdinJob):
 
             next_run = self._merge_cdc(cdc_watermark)
             self._write_status(next_run)
+            self._checkpoint_log()
 
             self.start_kwargs.update(
                 {
@@ -291,6 +292,13 @@ class CubicODSDelta(OdinJob):
             table=self.table,
             target_file_size=target,
         ).complete()
+
+    def _checkpoint_log(self) -> None:
+        """Collapse the commit log into a checkpoint at the end of the run."""
+        assert self.silver is not None
+        log = ProcessLog("delta_checkpoint_log", table=self.table)
+        self.silver.create_checkpoint()
+        log.complete(version=self.silver.version())
 
     def _db(self) -> duckdb.DuckDBPyConnection:
         """Return the run-scoped DuckDB connection, creating it on first use."""

--- a/src/odin/generate/cubic/delta_ods.py
+++ b/src/odin/generate/cubic/delta_ods.py
@@ -295,8 +295,11 @@ class CubicODSDelta(OdinJob):
 
     def _checkpoint_log(self) -> None:
         """Collapse the commit log into a checkpoint at the end of the run."""
-        assert self.silver is not None
         log = ProcessLog("delta_checkpoint_log", table=self.table)
+        # Re-open rather than trust the handle: create_checkpoint() checkpoints the
+        # version its handle is pinned to, not the table's latest, so a handle left
+        # stale by any commit above it silently leaves behind commits
+        self.silver = DeltaTable(self.silver_uri)
         self.silver.create_checkpoint()
         log.complete(version=self.silver.version())
 

--- a/tests/generate/cubic/delta_ods_test.py
+++ b/tests/generate/cubic/delta_ods_test.py
@@ -8,6 +8,7 @@ local Delta silver table, then call the steps directly and assert on silver's
 contents. DuckDB reads the parquet; delta-rs writes the silver table.
 """
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -1553,6 +1554,35 @@ def test_ensure_target_file_size_sets_then_leaves_property(job):
     version = DeltaTable(pipeline.silver_uri).version()
     pipeline._ensure_target_file_size()
     assert DeltaTable(pipeline.silver_uri).version() == version  # no second commit
+
+
+def test_checkpoint_log_leaves_nothing_to_replay(job):
+    """
+    A checkpoint at the run's end collapses the commits piled up behind it.
+
+    Readers replay only the commits *after* the newest checkpoint, and it is that
+    count -- not the log's total size -- that decides how many S3 responses the
+    delta kernel holds open while a query drains them.
+    """
+    pipeline, write_history, _, _ = job
+    write_history(history_rows([{"txn_id": 1, "amount": 10, "header__change_oper": "L"}]))
+    pipeline._rebuild_silver()
+
+    empty = pa.Table.from_pylist(
+        [], schema=pa.schema(DeltaTable(pipeline.silver_uri).schema().to_arrow())
+    )
+    for _ in range(5):
+        write_deltalake(pipeline.silver_uri, empty, mode="append")
+
+    pipeline.silver = DeltaTable(pipeline.silver_uri)
+    pipeline._checkpoint_log()
+
+    log_dir = Path(pipeline.silver_uri) / "_delta_log"
+    version = DeltaTable(pipeline.silver_uri).version()
+    assert (log_dir / f"{version:020d}.checkpoint.parquet").exists()
+    # Every commit is at or below the checkpoint, so a reader replays no JSON.
+    unconsolidated = [p for p in log_dir.glob("*.json") if int(p.stem) > version]
+    assert unconsolidated == []
 
 
 def test_discover_keys_ordered_by_primary_key_position():


### PR DESCRIPTION
We've been getting intermittent errors computing the edw_farerev_payg_trip_txn view (which is used in computing the larger COMP B views.) The error was clearly related to duckdb's delta table integration but was otherwise ambiguous:

`8754e949d08b ERROR uuid=ac804598-f161-48b5-9d0c-3dc98cd9af5f, _duckdb.IOException: IO Error: Failed to unpack scan data from kernel: DeltaKernel ObjectStoreError (8): Error interacting with object store: Generic S3 error: HTTP error: request or response body error`

Analysis from Claude suggests that this was due to the delta-kernel-rs behavior when reading delta tables which have multiple JSON commit files: it opens HTTP requests for all commit files since the latest checkpoint _simultaneously_, and then if duckdb can't work through the streaming data from all of these before S3's request timeout hits, this error occurs. The default behavior for delta-rs is to checkpoint after accumulating 100 JSON commit files, so this can be up to 100 simultaneous HTTP reads. (And the issue is probably exacerbated by the fact that we limit duckdb's to single-threaded operation here for memory reasons.)

Solution is to explicitly checkpoint after an update, so that we don't accumulate commit files at all, and delta-rs only has to read the (more efficiently handled) checkpoint parquet files for this step. This is a bookkeeping operation in the delta-rs interface, so shouldn't have any impact on data integrity.