### PR TITLE
Remove DEVICE_LAST_STATE from delta table processing

### DIFF
--- a/src/odin/ingestion/qlik/tables.py
+++ b/src/odin/ingestion/qlik/tables.py
@@ -49,7 +49,7 @@ TABLE_MANIFEST: Dict[str, List[str | None]] = {
     "EDW.DEVICE_DIMENSION": ["alpha", "alpha", None],
     "EDW.DEVICE_END_OF_DAY_MSG_COUNT": ["alpha", "alpha", None],
     "EDW.DEVICE_EVENT": ["alpha", "alpha", None],
-    "EDW.DEVICE_LAST_STATE": ["gamma", "gamma", "gamma"],
+    "EDW.DEVICE_LAST_STATE": ["gamma", "gamma", None],
     "EDW.EMPLOYEE_DIMENSION": ["alpha", "alpha", None],
     "EDW.EVENT_TYPE_DIMENSION": ["alpha", "alpha", None],
     "EDW.FACILITY_DIMENSION": ["alpha", "alpha", None],


### PR DESCRIPTION
DEVICE_LAST_STATE is processing faster on the legacy fact table system than on delta tables, as well as being less behind. Given this it seems unnecessary to have this table running as a delta table also, so this PR removes it from delta processing.