### PR TITLE
Suppress missing cubic snapshot error

### DIFF
--- a/src/odin/ingestion/qlik/cubic_archive.py
+++ b/src/odin/ingestion/qlik/cubic_archive.py
@@ -386,11 +386,16 @@ def schedule_cubic_archive_qlik(schedule: sched.scheduler) -> None:
     for table in CUBIC_HISTORY_TABLES:
         # This clean process should remain as long as new Qlik tables are being added.
         # This will move any qlik files, not associated with the most recent snapshot,
-        # to the "ignore" odin partition, if there is an existing processed shapshot, it is a no-op
+        # to the "ignore" odin partition, if there is an existing processed shapshot, it is a no-op.
+        # If there is an error here, we don't schedule the job for that table.
         try:
             clean_old_snapshots(table)
+        except IndexError as exception:
+            # Catch missing snapshot error, report as non-error
+            ProcessLog("schedule_cubic_archive_qlik", table=table,
+                       exception=repr(exception))
+            continue
         except Exception as exception:
-            # on Error don't schedule Archive Job
             log = ProcessLog("schedule_cubic_archive_qlik", table=table)
             log.failed(exception)
             continue

--- a/src/odin/ingestion/qlik/cubic_archive.py
+++ b/src/odin/ingestion/qlik/cubic_archive.py
@@ -392,8 +392,7 @@ def schedule_cubic_archive_qlik(schedule: sched.scheduler) -> None:
             clean_old_snapshots(table)
         except IndexError as exception:
             # Catch missing snapshot error, report as non-error
-            ProcessLog("schedule_cubic_archive_qlik", table=table,
-                       exception=repr(exception))
+            ProcessLog("schedule_cubic_archive_qlik", table=table, exception=repr(exception))
             continue
         except Exception as exception:
             log = ProcessLog("schedule_cubic_archive_qlik", table=table)


### PR DESCRIPTION
Tables with missing snapshots previously threw an exception which was logged as an error. This generated unnecessary error reports and would clutter up the Odin Sentry dashboard, so this PR now suppresses that exception (although occurrences are still logged.)